### PR TITLE
Fixed casing on System.Xml dependency

### DIFF
--- a/src/IdentityModel/project.json
+++ b/src/IdentityModel/project.json
@@ -16,7 +16,7 @@
       "frameworkAssemblies": {
         "System.IdentityModel": "4.0.0.0",
         "System.Net.Http": "4.0.0.0",
-        "System.XML": "4.0.0.0",
+        "System.Xml": "4.0.0.0",
         "System.Xml.Linq": "4.0.0.0"
       }
     },


### PR DESCRIPTION
The casing of the framework dependency System.Xml uses all caps for XML. I believe this causes a problem on Unix/Linux based systems when DNU/DNX locates the dependency.

The following is the output from running `dnu list` on Mac OS X:

```
$ dnu list src/IdentityModel
Microsoft .NET Development Utility Mono-x64-1.0.0-rc1-16609

Listing dependencies for IdentityModel (/Users/rm/Documents/temp/IdentityModel/src/IdentityModel/project.json)

[Target framework .NETFramework,Version=v4.5.1 (net451)]

Framework references:
  fx/Microsoft.CSharp 4.0.0
  fx/mscorlib 4.0.0
  fx/System 4.0.0
  fx/System.Core 4.0.0
  fx/System.IdentityModel 4.0.0
  fx/System.Net.Http 4.0.0
  fx/System.XML 4.0.0 - Unresolved
  fx/System.Xml.Linq 4.0.0

Package references:
* Newtonsoft.Json 6.0.4
```

Note the "Unresolved" after System.XML.

After changing the casing in `project.json` to System.Xml, the error is gone.
