### PR TITLE
.NET Core RC2 - .NET 4.6 Support

### DIFF
--- a/src/IdentityModel/project.json
+++ b/src/IdentityModel/project.json
@@ -1,18 +1,16 @@
 {
   "version": "2.0.0-beta1",
   "authors": [ "Dominick Baier", "Brock Allen" ],
-  
+
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-24027",
-    "Newtonsoft.Json": "8.0.3",
+    "Newtonsoft.Json": "8.0.4-beta1",
     "System.Security.Claims": "4.0.1-rc2-24027",
     "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24027",
     "System.Security.Cryptography.X509Certificates": "4.1.0-rc2-24027"
   },
 
   "frameworks": {
-    "netstandard1.5": {
-      "imports": "dnxcore50"
-    }
+    "netstandard1.3": { }
   }
 }


### PR DESCRIPTION
By using the new version of Newtonsoft.Json we are now able to target netstandard1.3 to support .NET 4.6 as well. Furthermore, we don't need the import of dnxcore50 anymore.
