### PR TITLE
Make Hawk buildable with either .NET 452 or NETSTANDARD 1.6

### DIFF
--- a/IdentityModelv2.sln
+++ b/IdentityModelv2.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2BF95931-60F6-4A54-9DF1-3EDB5D624AC0}"
 EndProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IdentityModel", "src\IdentityModel\IdentityModel.xproj", "{B0B96A68-D029-4B83-8475-00D9A2BB7965}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Hawk", "src\Hawk\Hawk.xproj", "{8FE4C35E-E9B5-4968-AA4C-FAD1E0DB8BE3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,11 +24,16 @@ Global
 		{B0B96A68-D029-4B83-8475-00D9A2BB7965}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0B96A68-D029-4B83-8475-00D9A2BB7965}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0B96A68-D029-4B83-8475-00D9A2BB7965}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FE4C35E-E9B5-4968-AA4C-FAD1E0DB8BE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FE4C35E-E9B5-4968-AA4C-FAD1E0DB8BE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FE4C35E-E9B5-4968-AA4C-FAD1E0DB8BE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FE4C35E-E9B5-4968-AA4C-FAD1E0DB8BE3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B0B96A68-D029-4B83-8475-00D9A2BB7965} = {2BF95931-60F6-4A54-9DF1-3EDB5D624AC0}
+		{8FE4C35E-E9B5-4968-AA4C-FAD1E0DB8BE3} = {2BF95931-60F6-4A54-9DF1-3EDB5D624AC0}
 	EndGlobalSection
 EndGlobal

--- a/src/Hawk/Client/ClientOptions.cs
+++ b/src/Hawk/Client/ClientOptions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Thinktecture.IdentityModel.Hawk.Core;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+namespace Thinktecture.IdentityModel.Hawk.Client
+{
+    public class ClientOptions
+    {
+        public ClientOptions()
+        {
+            this.EnableResponseValidation = true;
+            this.EnableAutoCompensationForClockSkew = true;
+        }
+
+        /// <summary>
+        /// Local time offset in milliseconds.
+        /// </summary>
+        public int LocalTimeOffsetMillis { get; set; }
+
+        /// <summary>
+        /// Set this to true for the server response to be validated using the artifacts in Server-Authorization header.
+        /// </summary>
+        public bool EnableResponseValidation { get; set; }
+
+        /// <summary>
+        /// Set this true for the skew between the client and the server clocks to be automatically compensated.
+        /// </summary>
+        public bool EnableAutoCompensationForClockSkew { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns the Credential.
+        /// </summary>
+        public Func<Credential> CredentialsCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns the normalized form of the request message to be used
+        /// as application specific data ('ext' field) in the Authorization request header.
+        /// </summary>
+        public Func<IRequestMessage, string> NormalizationCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns true if the specified normalized form of the response
+        /// message matches the normalized form of the specified response message.
+        /// </summary>
+        public Func<IResponseMessage, string, bool> VerificationCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns true, if the request body must be hashed and included
+        /// in the MAC ('mac' field) sent in the Authorization request header.
+        /// </summary>
+        public Func<IRequestMessage, bool> RequestPayloadHashabilityCallback { get; set; }
+	}
+}

--- a/src/Hawk/Client/HawkClient.cs
+++ b/src/Hawk/Client/HawkClient.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Thinktecture.IdentityModel.Hawk.Core;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Client
+{
+    /// <summary>
+    /// The counterpart of HawkServer in the client side that creates the HTTP Authorization header in hawk scheme
+    /// and authenticates the server response by validating the Server-Authorization response header.
+    /// HawkClient is for per-request use.
+    /// </summary>
+    public class HawkClient
+    {
+        private static readonly object myPrecious = new object();
+
+        private readonly ClientOptions options = null;
+
+        private ArtifactsContainer artifacts = null;
+        private Cryptographer crypto = null;
+
+        /// <summary>
+        /// Authenticates the server response by reading the Server-Authorization header and creates 
+        /// the the HTTP Authorization header in hawk scheme.
+        /// </summary>
+        /// <param name="options">Hawk authentication options</param>
+        public HawkClient(ClientOptions options)
+        {
+            if (options == null || options.CredentialsCallback == null)
+                throw new ArgumentNullException("Invalid Hawk authentication options. Credentials callback cannot be null.");
+
+            this.options = options;
+        }
+
+        /// <summary>
+        /// Added to current date time before computing the UNIX time. HawkClient can automatically
+        /// adjust the value in this property based on the timestamp sent by the service in the 
+        /// WWW-Authenticate header in an attempt to keep the server and the client clocks in sync.
+        /// </summary>
+        public static int CompensatorySeconds { get; private set; }
+
+        /// <summary>
+        /// Returns true, if the HMAC computed for the response payload matches the HMAC in the
+        /// Server-Authorization response header. This method also sets the compensation field so 
+        /// that the timestamp in the subsequent requests are adjusted to reduce the clock skew.
+        /// </summary>
+        public async Task<bool> AuthenticateAsync(IResponseMessage response)
+        {
+            if (response.StatusCode != HttpStatusCode.Unauthorized &&
+                    this.options.EnableResponseValidation &&
+                        await this.IsResponseTamperedAsync(artifacts, crypto, response))
+                return false;
+
+            if (this.options.EnableAutoCompensationForClockSkew &&
+                    this.IsTimestampResponseTampered(artifacts, response))
+                return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Creates the HTTP Authorization header in hawk scheme.
+        /// The counterpart of the CreateServerAuthorization method in HawkServer.
+        /// </summary>
+        /// <param name="request">Request object</param>
+        /// <returns></returns>
+        public async Task CreateClientAuthorizationAsync(IRequestMessage request)
+        {
+            HawkEventSource.Log.Debug(
+                String.Format("HawkClient.CreateClientAuthorizationAsync for {0} {1}",
+                                request.Method.ToString(),
+                                request.Uri.ToString()));
+
+            await CreateClientAuthorizationInternalAsync(request, DateTime.UtcNow);
+        }
+
+        /// <summary>
+        /// Adds the bewit to the query string of the specified HttpRequestMessage object and
+        /// returns the bewit string.
+        /// </summary>
+        public string CreateBewit(IRequestMessage request, int lifeSeconds)
+        {
+            HawkEventSource.Log.Debug(
+                String.Format("HawkClient.CreateBewit for {0} {1}",
+                                request.Method.ToString(),
+                                request.Uri.ToString()));
+
+            return CreateBewitInternal(request, DateTime.UtcNow, lifeSeconds);
+        }
+
+        /// <summary>
+        /// Adds the bewit to the query string of the specified HttpRequestMessage object and 
+        /// returns the bewit string.
+        /// </summary>
+        internal string CreateBewitInternal(IRequestMessage request, DateTime utcNow, int lifeSeconds)
+        {
+            string appData = null;
+            if (options.NormalizationCallback != null)
+                appData = options.NormalizationCallback(request);
+
+            var bewit = new Bewit(request, options.CredentialsCallback(),
+                                    utcNow, lifeSeconds, appData, options.LocalTimeOffsetMillis);
+            string bewitString = bewit.ToBewitString();
+
+            string parameter = String.Format("{0}={1}", HawkConstants.Bewit, bewitString);
+
+            string queryString = request.Uri.Query;
+            queryString = String.IsNullOrWhiteSpace(queryString) ? parameter : queryString.Substring(1) + "&" + parameter;
+            request.QueryString = queryString;
+
+            return bewitString;
+        }
+
+        /// <summary>
+        /// Creates the HTTP Authorization header in hawk scheme.
+        /// </summary>
+        internal async Task CreateClientAuthorizationInternalAsync(IRequestMessage request, DateTime utcNow)
+        {
+            var credential = options.CredentialsCallback();
+            this.artifacts = new ArtifactsContainer()
+            {
+                Id = credential.Id,
+                Timestamp = utcNow.AddSeconds(HawkClient.CompensatorySeconds).ToUnixTime(),
+                Nonce = NonceGenerator.Generate()
+            };
+
+            if (options.NormalizationCallback != null)
+                this.artifacts.ApplicationSpecificData = options.NormalizationCallback(request);
+
+            var normalizedRequest = new NormalizedRequest(request, this.artifacts);
+            this.crypto = new Cryptographer(normalizedRequest, this.artifacts, credential);
+
+            // Sign the request
+            bool includePayloadHash = options.RequestPayloadHashabilityCallback != null &&
+                                            options.RequestPayloadHashabilityCallback(request);
+
+            string payload = includePayloadHash ? await request.ReadBodyAsStringAsync() : null;
+            crypto.Sign(payload, request.ContentType);
+
+            request.Authorization = new AuthenticationHeaderValue(HawkConstants.Scheme,
+                                                this.artifacts.ToAuthorizationHeaderParameter());
+        }
+
+        /// <summary>
+        /// Returns true if the server response HMAC cannot be validated, indicating possible tampering.
+        /// </summary>
+        private async Task<bool> IsResponseTamperedAsync(ArtifactsContainer artifacts, Cryptographer crypto,
+                                                        IResponseMessage response)
+        {
+            if (response.Headers.ContainsKey(HawkConstants.ServerAuthorizationHeaderName))
+            {
+                string header = response.Headers[HawkConstants.ServerAuthorizationHeaderName].FirstOrDefault();
+
+                if (!String.IsNullOrWhiteSpace(header) &&
+                                    header.Substring(0, HawkConstants.Scheme.Length).ToLower() == HawkConstants.Scheme)
+                {
+                    ArtifactsContainer serverAuthorizationArtifacts;
+                    if (ArtifactsContainer.TryParse(header.Substring(HawkConstants.Scheme.Length + " ".Length),
+                                                                                    out serverAuthorizationArtifacts))
+                    {
+                        // To validate response, ext, hash, and mac in the request artifacts must be
+                        // replaced with the ones from the server.
+                        artifacts.ApplicationSpecificData = serverAuthorizationArtifacts.ApplicationSpecificData;
+                        artifacts.PayloadHash = serverAuthorizationArtifacts.PayloadHash;
+                        artifacts.Mac = serverAuthorizationArtifacts.Mac;
+
+                        // Response body is needed only if payload hash is present in the server response.
+                        string body = null;
+                        if (artifacts.PayloadHash != null && artifacts.PayloadHash.Length > 0)
+                        {
+                            body = await response.ReadBodyAsStringAsync();
+                        }
+
+                        bool isValid = crypto.IsSignatureValid(body, response.ContentType, isServerAuthorization: true);
+
+                        if (isValid)
+                        {
+                            string appSpecificData = serverAuthorizationArtifacts.ApplicationSpecificData;
+
+                            isValid = options.VerificationCallback == null ||
+                                                    options.VerificationCallback(response, appSpecificData);
+                        }
+
+                        return !isValid;
+                    }
+                }
+            }
+
+            return true; // Missing header means possible tampered response (to err on the side of caution).
+        }
+
+        /// <summary>
+        /// Returns true, if there is a WWW-Authenticate header containing ts and tsm but mac
+        /// computed for ts does not match tsm, indicating possible tampering. Otherwise, returns false.
+        /// This method also sets the compensation field so that the timestamp in the subsequent requests
+        /// are adjusted to reduce the clock skew.
+        /// </summary>
+        private bool IsTimestampResponseTampered(ArtifactsContainer artifacts, IResponseMessage response)
+        {
+            var wwwHeader = response.WwwAuthenticate;
+
+            if (wwwHeader != null)
+            {
+                string parameter = wwwHeader.Parameter;
+
+                ArtifactsContainer timestampArtifacts;
+                if (!String.IsNullOrWhiteSpace(parameter) &&
+                                ArtifactsContainer.TryParse(parameter, out timestampArtifacts))
+                {
+                    var ts = new NormalizedTimestamp(timestampArtifacts.Timestamp, options.CredentialsCallback(), options.LocalTimeOffsetMillis);
+
+                    if (!ts.IsValid(timestampArtifacts.TimestampMac))
+                        return true;
+
+                    lock (myPrecious)
+                        HawkClient.CompensatorySeconds = (int)(timestampArtifacts.Timestamp - DateTime.UtcNow.ToUnixTime());
+
+                    HawkEventSource.Log.TimestampMismatch(HawkClient.CompensatorySeconds);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Hawk/Client/HawkValidatingHandler.cs
+++ b/src/Hawk/Client/HawkValidatingHandler.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Net.Http;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Thinktecture.IdentityModel.Hawk.Etw;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.WebApi;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+
+namespace Thinktecture.IdentityModel.Hawk.Client
+{
+    /// <summary>
+    /// The client side message handler that adds the Authorization header to the request and validates the response.
+    /// </summary>
+    public class HawkValidationHandler : DelegatingHandler
+    {
+        private readonly ClientOptions options = null;
+
+        /// <summary>
+        /// The client side message handler that adds the Authorization header to the request and validates the response.
+        /// </summary>
+        /// <param name="options">Hawk authenitcation options</param>
+        public HawkValidationHandler(ClientOptions options)
+        {
+            if (options == null || options.CredentialsCallback == null)
+                throw new ArgumentNullException("Invalid Hawk authentication options. Credentials callback cannot be null.");
+
+            this.options = options;
+        }
+
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var client = new HawkClient(options);
+            await client.CreateClientAuthorizationAsync(new WebApiRequestMessage(request));
+
+            var response = await base.SendAsync(request, cancellationToken);
+            var responseMessage = new WebApiResponseMessage(response);
+
+            HawkEventSource.Log.Debug(String.Format("Response received with status of {0}", (int)responseMessage.StatusCode));
+
+            if (!await client.AuthenticateAsync(responseMessage))
+            {
+                string header = responseMessage.Headers.FirstOrDefault(HawkConstants.ServerAuthorizationHeaderName);
+                HawkEventSource.Log.ServerResponse((int)responseMessage.StatusCode, await responseMessage.ReadBodyAsStringAsync(), header ?? String.Empty);
+
+                throw new SecurityException("Invalid Mac and/or hash. Response possibly tampered.");
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Hawk/Core/ArtifactsContainer.cs
+++ b/src/Hawk/Core/ArtifactsContainer.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// CLR representation of the parameter data of Authorization, WWW-Authenticate, and Server-Authorization headers.
+    /// </summary>
+    internal class ArtifactsContainer
+    {
+        private const string VALUE_MATCH_PATTERN = @"^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$";
+        private const string PARAMETER_MATCH_PATTERN = @"(\w+)=""([^""\\]*)""\s*(?:,\s*|$)";
+        private const string SPECIFIC_PARAMETER_MATCH_PATTERN = @"({0})=""([^""\\]*)""\s*(?:,\s*|$)";
+
+        private const string ID = "id";
+        private const string TS = "ts";
+        private const string NONCE = "nonce";
+        private const string EXT = "ext";
+        private const string MAC = "mac";
+        private const string HASH = "hash";
+        private const string TSM = "tsm";
+
+        /// <summary>
+        /// Hawk credentials identifier.
+        /// </summary>
+        internal string Id { get; set; }
+
+        /// <summary>
+        /// Timestamp (UNIX time).
+        /// </summary>
+        internal ulong Timestamp { get; set; }
+
+        /// <summary>
+        /// Client generated nonce.
+        /// </summary>
+        internal string Nonce { get; set; }
+
+        /// <summary>
+        /// Application specific data that the client or the service can send along.
+        /// </summary>
+        internal string ApplicationSpecificData { get; set; }
+
+        /// <summary>
+        /// Hash-based message authentication code of the normalized request or response, created respectively
+        /// by the client or the service, using the shared secret key.
+        /// </summary>
+        internal byte[] Mac { get; set; }
+
+        /// <summary>
+        /// Hash of the normalized payload (request or response body). It is just a plain hash and not a 
+        /// hash-based message authentication code.
+        /// </summary>
+        internal byte[] PayloadHash { get; set; }
+
+        /// <summary>
+        /// Hash-based message authentication code of the normalized timestamp, created using the shared secret key
+        /// </summary>
+        internal byte[] TimestampMac { get; set; }
+
+        /// <summary>
+        /// Returns true if the client supplied artifacts of identifier, nonce, and MAC are non-empty and 
+        /// timestamp is greater than 0.
+        /// </summary>
+        internal bool AreClientArtifactsValid
+        {
+            get
+            {
+                return !String.IsNullOrWhiteSpace(this.Id) &&
+                                !String.IsNullOrWhiteSpace(this.Nonce) &&
+                                    (this.Mac != null && this.Mac.Length > 0) &&
+                                        this.Timestamp > 0;
+            }
+        }
+
+
+        /// <summary>
+        /// Attempts to convert the passed in header parameter (string) into the CLR equivalent, which is an
+        /// instance of ArtifactsContainer. The return value indicates whether the conversion succeeded.
+        /// </summary>
+        internal static bool TryParse(string headerParameter, out ArtifactsContainer container)
+        {
+            HawkEventSource.Log.Debug("Hawk Authorization: " + headerParameter);
+
+            ArtifactsContainer result = new ArtifactsContainer();
+
+            var keysToBeProcessed = new HashSet<string>() { ID, TS, NONCE, EXT, MAC, HASH, TSM };
+
+            var replacedString = Regex.Replace(headerParameter, PARAMETER_MATCH_PATTERN, (Match match) =>
+            {
+                string key = match.Groups[1].Value.Trim();
+                string value = match.Groups[2].Value.Trim();
+
+                bool isValidValue = Regex.Match(value, VALUE_MATCH_PATTERN).Success;
+                bool isValidKey = keysToBeProcessed.Any(k => k == key); // Key is neither duplicate nor bad
+
+                if (isValidValue && isValidKey)
+                {
+                    switch (key)
+                    {
+                        case ID: result.Id = value; break;
+
+                        case TS:
+                            {
+                                ulong timestamp;
+                                if (UInt64.TryParse(value, out timestamp))
+                                {
+                                    result.Timestamp = timestamp;
+                                    break;
+                                }
+                                else
+                                    return value;
+                            }
+
+                        case NONCE: result.Nonce = value; break;
+                        case EXT: result.ApplicationSpecificData = value; break;
+                        case MAC: result.Mac = value.ToBytesFromBase64(); break;
+                        case HASH: result.PayloadHash = value.ToBytesFromBase64(); break;
+                        case TSM: result.TimestampMac = value.ToBytesFromBase64(); break;
+                    }
+
+                    keysToBeProcessed.Remove(key); // Processed
+
+                    return String.Empty;
+                }
+                else
+                    return value;
+            });
+
+            if (replacedString == String.Empty) // No more, no less -> valid parameter data
+            {
+                container = result;
+                return true;
+            }
+
+            HawkEventSource.Log.UnparsedArtifact(replacedString);
+
+            container = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true, if the passed in header parameter contains the hash field.
+        /// </summary>
+        internal static bool IsPayloadHashPresent(string headerParameter)
+        {
+            string pattern = String.Format(SPECIFIC_PARAMETER_MATCH_PATTERN, HASH);
+
+            if (!String.IsNullOrWhiteSpace(headerParameter))
+                if (Regex.IsMatch(headerParameter, pattern))
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the header parameter to be put into the HTTP Authorization header in hawk scheme.
+        /// </summary>
+        internal string ToAuthorizationHeaderParameter()
+        {
+            return this.ToHeaderParameter(true);
+        }
+
+        /// <summary>
+        /// Returns the header parameter to be put into the Server-Authorization header.
+        /// Intended to be used only by HawkServer, while creating the Server-Authorization header
+        /// and hence the scope of this method is internal.
+        /// </summary>
+        internal string ToServerAuthorizationHeaderParameter()
+        {
+            return this.ToHeaderParameter(
+                                includeClientArtifacts: false); // Do not need the client supplied id, ts, and nonce
+        }
+
+        /// <summary>
+        /// Returns the serialized form of this object.
+        /// </summary>
+        /// <param name="includeClientArtifacts">If true, the client supplied artifacts of id, timestamp, and nonce are included.</param>
+        /// <returns></returns>
+        private string ToHeaderParameter(bool includeClientArtifacts)
+        {
+            char trailer = ',';
+            StringBuilder result = new StringBuilder();
+
+            if (includeClientArtifacts)
+            {
+                result
+                    .AppendIfNotEmpty(ID, this.Id, trailer)
+                    .AppendIfNotEmpty(TS, (this.Timestamp > 0 ? this.Timestamp.ToString() : String.Empty), trailer)
+                    .AppendIfNotEmpty(NONCE, this.Nonce, trailer);
+            }
+
+            result
+                .AppendIfNotEmpty(EXT, this.ApplicationSpecificData, trailer)
+                .AppendIfNotEmpty(MAC, this.Mac == null ? null : this.Mac.ToBase64String(), trailer)
+                .AppendIfNotEmpty(HASH, this.PayloadHash == null ? null : this.PayloadHash.ToBase64String(), trailer);
+
+            return result.ToString()
+                .Trim().Trim(trailer); // Remove the trailing trailer and space for the last pair
+        }
+    }
+}

--- a/src/Hawk/Core/AuthenticationResult.cs
+++ b/src/Hawk/Core/AuthenticationResult.cs
@@ -1,0 +1,29 @@
+﻿
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// The result of the authentication process.
+    /// </summary>
+    internal class AuthenticationResult
+    {
+        /// <summary>
+        /// The Credential object corresponding to the identifier in the request
+        /// </summary>
+        internal Credential Credential { get; set; }
+
+        /// <summary>
+        /// The ArtifactsContainer object containing the client supplied artifacts such as timestamp, hash, mac, etc.
+        /// </summary>
+        internal ArtifactsContainer Artifacts { get; set; }
+
+        /// <summary>
+        /// True, if the authentication process is successful.
+        /// </summary>
+        internal bool IsAuthentic { get; set; }
+
+        /// <summary>
+        /// The application specific data sent by the client (if any).
+        /// </summary>
+        internal string ApplicationSpecificData { get; set; }
+    }
+}

--- a/src/Hawk/Core/Bewit.cs
+++ b/src/Hawk/Core/Bewit.cs
@@ -1,0 +1,174 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using System;
+using System.Net.Http;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Represents the query parameter bewit used by Hawk for granting temporary access.
+    /// </summary>
+    internal class Bewit
+    {
+        private readonly Credential credential = null;
+        private readonly IRequestMessage request = null;
+        private readonly DateTime utcNow = DateTime.UtcNow;
+        private readonly int lifeSeconds = 60;
+        private readonly string applicationSpecificData = String.Empty;
+        private readonly int localOffset = 0;
+
+        /// <summary>
+        /// Represents the query parameter bewit used by Hawk for granting temporary access.
+        /// </summary>
+        /// <param name="request">Request object</param>
+        /// <param name="credential">Hawk credential to use for creating and validating bewit.</param>
+        /// <param name="utcNow">Current date and time in UTC.</param>
+        /// <param name="lifeSeconds">Bewit life time (time to live in seconds).</param>
+        /// <param name="applicationSpecificData">Application specific data to be sent in the bewit</param>
+        /// <param name="localOffset">Local offset in milliseconds.</param>
+        internal Bewit(IRequestMessage request, Credential credential,
+                            DateTime utcNow, int lifeSeconds, string applicationSpecificData, int localOffset = 0)
+        {
+            this.credential = credential;
+            this.request = request;
+            this.utcNow = utcNow;
+            this.lifeSeconds = lifeSeconds;
+            this.applicationSpecificData = applicationSpecificData;
+            this.localOffset = localOffset;
+        }
+
+        /// <summary>
+        /// Returns the string representation of the bewit, which is a base64 URL encoded string of format
+        /// id\exp\mac\ext, where id is the user identifier, exp is the UNIX time until which bewit is
+        /// valid, mac is the HMAC of the bewit to protect integrity, and ext is the application specific data.
+        /// </summary>
+        public string ToBewitString()
+        {
+            if (request.Method != HttpMethod.Get) // Not supporting HEAD
+                throw new InvalidOperationException("Bewit not allowed for methods other than GET");
+
+            ulong now = utcNow.ToUnixTime() + Convert.ToUInt64(this.localOffset);
+
+            var artifacts = new ArtifactsContainer()
+            {
+                Id = credential.Id,
+                Timestamp = now + (ulong)lifeSeconds,
+                Nonce = String.Empty,
+                ApplicationSpecificData = this.applicationSpecificData ?? String.Empty
+            };
+
+            var normalizedRequest = new NormalizedRequest(request, artifacts) { IsBewit = true };
+            var crypto = new Cryptographer(normalizedRequest, artifacts, credential);
+
+            // Sign the request
+            crypto.Sign(); // Bewit is for GET and GET must have no request body
+
+            // bewit: id\exp\mac\ext
+            string bewit = String.Format(@"{0}\{1}\{2}\{3}",
+                                credential.Id,
+                                artifacts.Timestamp,
+                                artifacts.Mac.ToBase64String(),
+                                artifacts.ApplicationSpecificData);
+
+            return bewit.ToBytesFromUtf8().ToBase64UrlString();
+        }
+
+        /// <summary>
+        /// Returns true, if a query string parameter with a name of 'bewit' exists and that there
+        /// is no HTTP Authorization header present in the request. Also, returns the value of the
+        /// bewit parameter from the query string.
+        /// </summary>
+        internal static bool TryGetBewit(IRequestMessage request, out string bewit)
+        {
+            bewit = QueryHelpers.ParseQuery(request.Uri.Query)[HawkConstants.Bewit];
+            
+            return !String.IsNullOrWhiteSpace(bewit) &&
+                        (request.Authorization == null);
+        }
+
+        /// <summary>
+        /// Returns an AuthenticationResult object corresponding to the result of authentication done
+        /// using the client supplied artifacts in the bewit query string parameter.
+        /// </summary>
+        /// <param name="bewit">Value of the query string parameter with the name of 'bewit'.</param>
+        /// <param name="now">Date and time in UTC to be used as the base for computing bewit life.</param>
+        /// <param name="request">Request object.</param>
+        /// <param name="options">Hawk authentication options</param>
+        internal static AuthenticationResult Authenticate(string bewit, ulong now, IRequestMessage request, Options options)
+        {
+            if (!String.IsNullOrWhiteSpace(bewit))
+            {
+                if (request.Method == HttpMethod.Get)
+                {
+                    if (options != null && options.CredentialsCallback != null)
+                    {
+                        var parts = bewit.ToUtf8StringFromBase64Url().Split('\\');
+
+                        if (parts.Length == 4)
+                        {
+                            ulong timestamp = 0;
+                            if (UInt64.TryParse(parts[1], out timestamp) && timestamp * 1000 > now)
+                            {
+                                string id = parts[0];
+                                string mac = parts[2];
+                                string ext = parts[3];
+
+                                if (!String.IsNullOrWhiteSpace(id) && !String.IsNullOrWhiteSpace(mac))
+                                {
+                                    RemoveBewitFromUri(request);
+
+                                    Credential credential = options.CredentialsCallback(id);
+                                    if (credential != null && credential.IsValid)
+                                    {
+                                        var artifacts = new ArtifactsContainer()
+                                        {
+                                            Id = id,
+                                            Nonce = String.Empty,
+                                            Timestamp = timestamp,
+                                            Mac = mac.ToBytesFromBase64(),
+                                            ApplicationSpecificData = ext ?? String.Empty
+                                        };
+
+                                        var normalizedRequest = new NormalizedRequest(request, artifacts) { IsBewit = true };
+                                        var crypto = new Cryptographer(normalizedRequest, artifacts, credential);
+
+                                        if (crypto.IsSignatureValid()) // Bewit is for GET and GET must have no request body
+                                        {
+                                            return new AuthenticationResult()
+                                            {
+                                                IsAuthentic = true,
+                                                Credential = credential,
+                                                Artifacts = artifacts,
+                                                ApplicationSpecificData = ext
+                                            };
+                                        }   
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return new AuthenticationResult() { IsAuthentic = false };
+        }
+
+        /// <summary>
+        /// Removes the bewit parameter from the URI of the specified IRequestMessage object.
+        /// </summary>
+        private static void RemoveBewitFromUri(IRequestMessage request)
+        {
+            string query = request.Uri.Query;
+            string bewit = QueryHelpers.ParseQuery(request.Uri.Query)[HawkConstants.Bewit];
+
+            query = query.Replace(HawkConstants.Bewit + "=" + bewit, String.Empty)
+                            .Replace("&&", "&")
+                            .Replace("?&", "?")
+                            .Trim('&').Trim('?');
+
+            request.QueryString = query;
+        }
+    }
+}

--- a/src/Hawk/Core/Credential.cs
+++ b/src/Hawk/Core/Credential.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Hawk credential
+    /// </summary>
+    public class Credential
+    {
+        /// <summary>
+        /// Identifier that can be used by a client to uniquely identify an entity (user).
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Shared symmetric key that is exchanged out-of-band between the service and the client.
+        /// </summary>
+        public byte[] Key { get; set; }
+
+        /// <summary>
+        /// Owner of the credential. If the owner is a human user, user name can be stored here.
+        /// Else, the application name.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
+        /// The hashing algorithm that the client and the service have agreed to use to create the 
+        /// payload hash as well as HMAC of the request and timestamp.
+        /// </summary>
+        public SupportedAlgorithms Algorithm { get; set; }
+
+        /// <summary>
+        /// Returns true, if the identifier is not empty, the shared secret key is not empty, and
+        /// the hashing algorithm is one of the algorithms defined in the SupportedAlgorithms enum.
+        /// </summary>
+        public bool IsValid
+        {
+            get
+            {
+                bool isIdValid = !String.IsNullOrWhiteSpace(this.Id);
+                bool isKeyValid = this.Key != null;
+                bool isAlogorithmValid = Enum.IsDefined(typeof(SupportedAlgorithms), this.Algorithm);
+
+                return isIdValid && isKeyValid && isAlogorithmValid;
+            }
+        }
+    }
+}

--- a/src/Hawk/Core/Cryptographer.cs
+++ b/src/Hawk/Core/Cryptographer.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Text;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// The class responsible for validating the HMAC in the request (in case of service) and the response (in case of the client)
+    /// and signing the request (in case of client) and response (in case of service) by creating an HMAC.
+    /// </summary>
+    internal class Cryptographer
+    {
+        private readonly ArtifactsContainer artifacts = null;
+        private readonly Credential credential = null;
+        private readonly NormalizedRequest normalizedRequest = null;
+        private readonly Hasher hasher = null;
+
+        internal Cryptographer(NormalizedRequest request, ArtifactsContainer artifacts, Credential credential)
+        {
+            this.normalizedRequest = request;
+            this.artifacts = artifacts;
+            this.credential = credential;
+            this.hasher = new Hasher(credential.Algorithm);
+        }
+
+        /// <summary>
+        /// Returns true, if the HMAC computed for the normalized request matches the HMAC 
+        /// sent in by the client (ArtifactsContainer.Mac) and if a payload hash is present,
+        /// it matches the hash computed for the normalized payload as well.
+        /// </summary>
+        internal bool IsSignatureValid(string body = null, string contentType = null, bool isServerAuthorization = false)
+        {
+            return this.IsMacValid(isServerAuthorization) && (this.IsHashNotPresent() || this.IsHashValid(body, contentType));
+        }
+
+        /// <summary>
+        /// Creates the payload hash and the corresponding HMAC, and updates the artifacts object
+        /// with these new values.
+        /// </summary>
+        internal void Sign(string body = null, string contentType = null)
+        {
+            byte[] responsePayloadHash = null;
+            if (body != null && contentType != null)
+            {
+                var payload = new NormalizedPayload(body, contentType);
+                byte[] data = payload.ToBytes();
+
+                responsePayloadHash = hasher.ComputeHash(data);
+            }
+
+            artifacts.PayloadHash = responsePayloadHash;
+
+            byte[] normalizedRequest = this.normalizedRequest.ToBytes();
+            artifacts.Mac = hasher.ComputeHmac(normalizedRequest, credential.Key);
+        }
+
+        private bool IsMacValid(bool isServerAuthorization = false)
+        {
+            this.normalizedRequest.IsServerAuthorization = isServerAuthorization;
+            byte[] data = this.normalizedRequest.ToBytes();
+            // data, at this point has the hash coming in over the wire and hence mac computed is
+            // based on the hash over the wire and not over the computed hash
+
+            bool isMacValid = this.hasher.IsValidMac(data, credential.Key, artifacts.Mac);
+
+            if (!isMacValid)
+                HawkEventSource.Log.Debug(
+                    String.Format("Invalid Mac {0} for data {1}",
+                                        artifacts.Mac.ToBase64String(), Encoding.UTF8.GetString(data)));
+            return isMacValid;
+        }
+
+        private bool IsHashNotPresent()
+        {
+            bool isHashAbsent = artifacts.PayloadHash == null || artifacts.PayloadHash.Length == 0;
+
+            HawkEventSource.Log.Debug(isHashAbsent ? "Payload Hash absent" : "Payload Hash present");
+            
+            return isHashAbsent;
+        }
+
+        private bool IsHashValid(string body, string contentType)
+        {
+            var normalizedPayload = new NormalizedPayload(body, contentType);
+            byte[] data = normalizedPayload.ToBytes();
+
+            bool isHashValid = this.hasher.IsValidHash(data, artifacts.PayloadHash);
+
+            if (!isHashValid)
+                HawkEventSource.Log.Debug(
+                    String.Format("Invalid payload hash {0} for data {1}",
+                                    artifacts.PayloadHash.ToBase64String(), Encoding.UTF8.GetString(data)));
+
+            return isHashValid;
+        }
+    }
+}

--- a/src/Hawk/Core/Extensions/ByteExtension.cs
+++ b/src/Hawk/Core/Extensions/ByteExtension.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Extensions
+{
+    internal static class ByteExtension
+    {
+        /// <summary>
+        /// Compare two byte arrays using constant-time algorithm (to prevent time-based analysis of MAC digest match).
+        /// </summary>
+        /// <param name="a">The first byte array</param>
+        /// <param name="b">The second byte array (base64 encoded)</param>
+        /// <returns>true, if the arrays are equal byte for byte</returns>
+        internal static bool IsConstantTimeEqualTo(this byte[] a, byte[] b)
+        {
+            bool areEqual = (a.Length == b.Length ? true : false);
+            if (!areEqual)
+                b = a; // Not equal but we do not bail out until we inspect all the elements in the array
+            
+            for (int i = 0; i < a.Length; i++)
+                areEqual = areEqual && (a[i] == b[i]);
+
+            return areEqual;
+        }
+
+        /// <summary>
+        /// Converts a byte array to its equivalent string representation that is base-64 encoded.
+        /// </summary>
+        internal static string ToBase64String(this byte[] bytes)
+        {
+            return Convert.ToBase64String(bytes);
+        }
+
+        /// <summary>
+        /// Converts a byte array to its equivalent string representation that is base-64 URL encoded.
+        /// </summary>
+        internal static string ToBase64UrlString(this byte[] bytes)
+        {
+            return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        }
+    }
+}

--- a/src/Hawk/Core/Extensions/DateTimeExtension.cs
+++ b/src/Hawk/Core/Extensions/DateTimeExtension.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Extensions
+{
+    internal static class DateTimeExtension
+    {
+        /// <summary>
+        /// Converts DateTime to its equivalent UNIX time expressed in milliseconds. Unix time is the number of seconds elapsed since Jan 1, 1970 midnight UTC.
+        /// </summary>
+        internal static ulong ToUnixTimeMillis(this DateTime dateTime)
+        {
+            DateTime epochStart = new DateTime(1970, 01, 01, 0, 0, 0, 0, DateTimeKind.Utc);
+            TimeSpan ts = dateTime - epochStart;
+            
+            return Convert.ToUInt64(ts.TotalSeconds * 1000);
+        }
+
+        /// <summary>
+        /// Converts DateTime to its equivalent UNIX time, the number of seconds elapsed since Jan 1, 1970 midnight UTC.
+        /// </summary>
+        internal static ulong ToUnixTime(this DateTime dateTime)
+        {
+            return dateTime.ToUnixTimeMillis() / 1000;
+        }
+    }
+}

--- a/src/Hawk/Core/Extensions/IDictionaryExtension.cs
+++ b/src/Hawk/Core/Extensions/IDictionaryExtension.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Extensions
+{
+    public static class IDictionaryExtension
+    {
+        public static string FirstOrDefault(this IDictionary<string, string[]> headers, string headerName)
+        {
+            string value = null;
+
+            string[] values = null;
+            if (headers.TryGetValue(headerName, out values))
+                value = values[0];
+
+            return value;
+
+        }
+    }
+}

--- a/src/Hawk/Core/Extensions/IRequestMessageExtension.cs
+++ b/src/Hawk/Core/Extensions/IRequestMessageExtension.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Extensions
+{
+    internal static class IRequestMessageExtension
+    {
+        /// <summary>
+        /// Returns true if there is an Authorization HTTP header present in the request, the header has a scheme 
+        /// that is "hawk" and that the parameter in the header is not empty.
+        /// </summary>
+        internal static bool HasValidHawkScheme(this IRequestMessage request)
+        {
+            var header = request.Authorization;
+
+            return (header != null && header.Scheme.ToLower() == HawkConstants.Scheme &&
+                                    !String.IsNullOrWhiteSpace(header.Parameter));
+        }
+    }
+}

--- a/src/Hawk/Core/Extensions/StringBuilderExtension.cs
+++ b/src/Hawk/Core/Extensions/StringBuilderExtension.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Text;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Extensions
+{
+    internal static class StringBuilderExtension
+    {
+        /// <summary>
+        /// Appends the key-value in the form of key="value" with a trailing trailer
+        /// and a space, if value is not null or String.Empty
+        /// </summary>
+        internal static StringBuilder AppendIfNotEmpty(this StringBuilder builder, string key, string value, char trailer)
+        {
+            if (!String.IsNullOrEmpty(value))
+            {
+                builder.AppendFormat("{0}=\"{1}\"", key, value).Append(trailer).Append(" ");
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the string followed by a new line (\n) to the StringBuilder object, substituting an empty string in case
+        /// the passed in string is null. The out-of-box AppendLine method is not used  because default line terminator is
+        /// not just a new line character.
+        /// </summary>
+        internal static StringBuilder AppendNewLine(this StringBuilder builder, string value)
+        {
+            builder.Append(value ?? String.Empty).Append("\n");
+
+            return builder;
+        }
+    }
+}

--- a/src/Hawk/Core/Extensions/StringExtension.cs
+++ b/src/Hawk/Core/Extensions/StringExtension.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Text;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Extensions
+{
+    internal static class StringExtension
+    {
+        /// <summary>
+        /// Returns the byte array corresponding to the UTF-8 encoded string.
+        /// </summary>
+        internal static byte[] ToBytesFromUtf8(this string utf8String)
+        {
+            return Encoding.UTF8.GetBytes(utf8String);
+        }
+
+        /// <summary>
+        /// Returns the byte array corresponding to the base-64 encoded string.
+        /// </summary>
+        internal static byte[] ToBytesFromBase64(this string base64EncodedString)
+        {
+            return Convert.FromBase64String(base64EncodedString);
+        }
+
+        /// <summary>
+        /// Returns the UTF-8 string corresponding to the base-64 URL encoded string.
+        /// </summary>
+        internal static string ToUtf8StringFromBase64Url(this string base64UrlEncodedString)
+        {
+            string input = base64UrlEncodedString;
+
+            input = input.Replace('-', '+').Replace('_', '/');
+            int pad = 4 - (input.Length % 4);
+            pad = pad > 2 ? 0 : pad;
+            input = input.PadRight(input.Length + pad, '=');
+            
+            return Encoding.UTF8.GetString(
+                            Convert.FromBase64String(input));
+        }
+
+        /// <summary>
+        /// Returns true, if the specified string can be parsed to System.Boolean.
+        /// </summary>
+        internal static bool ToBool(this string input)
+        {
+            return Boolean.Parse(input);
+        }
+    }
+}

--- a/src/Hawk/Core/HawkSchemeHeader.cs
+++ b/src/Hawk/Core/HawkSchemeHeader.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Threading.Tasks;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Represents the HTTP authorization header in hawk scheme.
+    /// </summary>
+    internal class HawkSchemeHeader
+    {
+        /// <summary>
+        /// Returns an AuthenticationResult object corresponding to the result of authentication done
+        /// using the client supplied artifacts in the HTTP authorization header in hawk scheme.
+        /// </summary>
+        /// <param name="now">Current UNIX time in milliseconds.</param>
+        /// <param name="request">Request object.</param>
+        /// <param name="options">Hawk authentication options</param>
+        /// <returns></returns>
+        internal static async Task<AuthenticationResult> AuthenticateAsync(ulong now, IRequestMessage request, Options options)
+        {
+            ArtifactsContainer artifacts = null;
+            Credential credential = null;
+
+            if (request.HasValidHawkScheme())
+            {
+                if (ArtifactsContainer.TryParse(request.Authorization.Parameter, out artifacts))
+                {
+                    if (artifacts != null && artifacts.AreClientArtifactsValid)
+                    {
+                        string lastUsedBy = options.DetermineNonceReplayCallback(artifacts.Nonce);
+
+                        if (String.IsNullOrEmpty(lastUsedBy)) // Not an old nonce, and hence not a replay.
+                        {
+                            credential = options.CredentialsCallback(artifacts.Id);
+                            if (credential != null && credential.IsValid)
+                            {
+                                HawkEventSource.Log.Debug(
+                                    String.Format("Algorithm={0} Key={1} ID={2}",
+                                                        credential.Algorithm.ToString(),
+                                                        Convert.ToBase64String(credential.Key),
+                                                        credential.Id));
+
+                                Tuple<string, string> hostAndPort = options.DetermineHostDetailsCallback(request);
+                                var normalizedRequest = new NormalizedRequest(request, artifacts, hostAndPort.Item1, hostAndPort.Item2);
+                                var crypto = new Cryptographer(normalizedRequest, artifacts, credential);
+
+                                // Request body is needed only when payload hash is present in the request
+                                string body = null;
+                                if (artifacts.PayloadHash != null && artifacts.PayloadHash.Length > 0)
+                                {
+                                    body = await request.ReadBodyAsStringAsync();
+                                }
+
+                                if (crypto.IsSignatureValid(body, request.ContentType)) // MAC and hash checks
+                                {
+                                    if (IsTimestampFresh(now, artifacts, options))
+                                    {
+                                        // If you get this far, you are authentic. Welcome and thanks for flying Hawk!
+
+                                        // Before returning the result, store nonce to detect replays.
+                                        options.StoreNonceCallback(artifacts.Nonce, credential.Id, options.ClockSkewSeconds);
+
+                                        return new AuthenticationResult()
+                                        {
+                                            IsAuthentic = true,
+                                            Artifacts = artifacts,
+                                            Credential = credential,
+                                            ApplicationSpecificData = artifacts.ApplicationSpecificData
+                                        };
+                                    }
+                                    else
+                                    {
+                                        // Authentic but for the timestamp freshness.
+                                        // Give a chance to the client to correct the clocks skew.
+                                        var timestamp = new NormalizedTimestamp(DateTime.UtcNow, credential, options.LocalTimeOffsetMillis);
+                                        request.ChallengeParameter = timestamp.ToWwwAuthenticateHeaderParameter();
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            HawkEventSource.Log.NonceReplay(artifacts.Nonce, lastUsedBy);
+                        }
+                    }
+                }
+            }
+
+            return new AuthenticationResult() { IsAuthentic = false };
+        }
+
+        /// <summary>
+        /// Returns true if the timestamp sent in by the client is fresh subject to the 
+        /// maximum allowed skew and the adjustment offset.
+        /// </summary>
+        private static bool IsTimestampFresh(ulong now, ArtifactsContainer artifacts, Options options)
+        {
+            now = now + Convert.ToUInt64(options.LocalTimeOffsetMillis);
+
+            ulong shelfLife = (Convert.ToUInt64(options.ClockSkewSeconds) * 1000);
+            var age = Math.Abs((artifacts.Timestamp * 1000.0) - now);
+
+            bool isFresh = (age <= shelfLife);
+
+            if (!isFresh)
+                HawkEventSource.Log.StaleTimestamp(age.ToString(), shelfLife.ToString());
+
+            return isFresh;
+        }
+    }
+}

--- a/src/Hawk/Core/HawkServer.cs
+++ b/src/Hawk/Core/HawkServer.cs
@@ -1,0 +1,155 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Authenticates the incoming request based on the Authorize request header or bewit query string parameter
+    /// and sets the Server-Authorization or the WWW-Authenticate response header. HawkServer is for per-request use.
+    /// </summary>
+    public class HawkServer
+    {
+        private readonly IRequestMessage request = null;
+        private readonly Options options = null;
+
+        private ulong now = 0;
+        private AuthenticationResult result = null;
+
+        internal bool IsBewitRequest { get; set; }
+
+        /// <summary>
+        /// Authenticates the incoming request based on the Authorize request header or bewit query string parameter
+        /// </summary>
+        /// <param name="request">The request object to be authenticated</param>
+        /// <param name="options">Hawk authentication options</param>
+        public HawkServer(IRequestMessage request, Options options)
+        {
+            now = DateTime.UtcNow.ToUnixTimeMillis(); // Record time before doing anything else
+
+            if (options == null || options.CredentialsCallback == null)
+                throw new ArgumentNullException("Invalid Hawk authentication options. Credentials callback cannot be null.");
+
+            this.request = request;
+            this.options = options;
+        }
+
+        /// <summary>
+        /// Returns a ClaimsPrincipal object with the NameIdentifier and Name claims, if the request can be
+        /// successfully authenticated based on query string parameter bewit or HTTP Authorization header (hawk scheme).
+        /// </summary>
+        public async Task<ClaimsPrincipal> AuthenticateAsync()
+        {
+            HawkEventSource.Log.Debug(
+                String.Format("Begin HawkServer.AuthenticateAsync for {0} {1}",
+                                request.Method.ToString(),
+                                request.Uri.ToString()));
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.Name, String.Empty) }));
+
+            string bewit;
+            bool isBewit = Bewit.TryGetBewit(this.request, out bewit);
+
+            this.result = isBewit ?
+                                Bewit.Authenticate(bewit, now, request, options) :
+                                    await HawkSchemeHeader.AuthenticateAsync(now, request, options);
+
+            if (result.IsAuthentic)
+            {
+                HawkEventSource.Log.Debug("Authentication Successful");
+
+                // At this point, authentication is successful but make sure the request parts match what is in the
+                // application specific data 'ext' parameter by invoking the callback passing in the request object and 'ext'.
+                // The application specific data is considered verified, if the callback is not set or it returns true.
+                bool isAppSpecificDataVerified = options.VerificationCallback == null ||
+                                                    options.VerificationCallback(request, result.ApplicationSpecificData);
+
+                if (isAppSpecificDataVerified)
+                {
+                    // Set the flag so that Server-Authorization header is not sent for bewit requests.
+                    this.IsBewitRequest = isBewit;
+
+                    var idClaim = new Claim(ClaimTypes.NameIdentifier, result.Credential.Id);
+                    var nameClaim = new Claim(ClaimTypes.Name, result.Credential.User);
+
+                    var identity = new ClaimsIdentity(new[] { idClaim, nameClaim }, HawkConstants.Scheme);
+
+                    principal = new ClaimsPrincipal(identity);
+                }
+                else
+                    HawkEventSource.Log.Debug("Invalid Application Specific Data, though authentication is successful");
+            }
+
+            HawkEventSource.Log.Debug("End HawkServer.AuthenticateAsync");
+
+            return principal;
+        }
+
+        /// <summary>
+        /// Returns the name of the response header (WWW-Authenticate or Server-Authorization) and the corresponding
+        /// value, respectively for an unauthorized and a successful request.
+        /// </summary>
+        public async Task<Tuple<string, string>> CreateServerAuthorizationAsync(IResponseMessage response)
+        {
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                string challenge = String.Format(" {0}", request.ChallengeParameter ?? String.Empty);
+                string headerValue = HawkConstants.Scheme + challenge.TrimEnd(' ');
+
+                return new Tuple<string, string>(HawkConstants.WwwAuthenticateHeaderName, headerValue);
+            }
+            else
+            {
+                // No Server-Authorization header for the following:
+                // (1) There is no result or failed authentication.
+                // (2) The credential is a bewit.
+                // (3) The server is configured to not send the header.
+                bool createHeader = this.result != null
+                                        && this.result.IsAuthentic
+                                            && (!this.IsBewitRequest)
+                                                && options.EnableServerAuthorization;
+
+                if (createHeader)
+                {
+                    if (options.NormalizationCallback != null)
+                        this.result.Artifacts.ApplicationSpecificData = options.NormalizationCallback(response);
+
+                    // Sign the response
+                    Tuple<string, string> hostAndPort = options.DetermineHostDetailsCallback(request);
+                    var normalizedRequest = new NormalizedRequest(request, this.result.Artifacts, hostAndPort.Item1, hostAndPort.Item2)
+                    {
+                        IsServerAuthorization = true
+                    };
+                    var crypto = new Cryptographer(normalizedRequest, this.result.Artifacts, this.result.Credential);
+
+                    // Response body is needed only if payload hash must be included in the response MAC.
+                    string body = null;
+                    if (options.ResponsePayloadHashabilityCallback != null &&
+                            options.ResponsePayloadHashabilityCallback(this.request))
+                    {
+                        body = await response.ReadBodyAsStringAsync();
+                    }
+
+                    crypto.Sign(body, response.ContentType);
+
+                    string authorization = this.result.Artifacts.ToServerAuthorizationHeaderParameter();
+
+                    if (!String.IsNullOrWhiteSpace(authorization))
+                    {
+                        return new Tuple<string, string>(HawkConstants.ServerAuthorizationHeaderName,
+                            String.Format("{0} {1}", HawkConstants.Scheme, authorization));
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Hawk/Core/Helpers/Hasher.cs
+++ b/src/Hawk/Core/Helpers/Hasher.cs
@@ -1,0 +1,96 @@
+﻿using System;
+#if NET452
+using System.Security.Cryptography;
+using Thinktecture.IdentityModel.Hawk.Etw;
+#endif
+using Hawk.Middleware;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Helpers
+{
+    /// <summary>
+    /// The class responsible for creating and validating hash and HMAC.
+    /// </summary>
+    internal class Hasher
+    {
+        private readonly string algorithmName;
+
+        /// <summary>
+        /// The class responsible for creating and validating hash and HMAC.
+        /// </summary>
+        /// <param name="algorithmToUse">The hashing algorithm to use</param>
+        internal Hasher(SupportedAlgorithms algorithmToUse)
+        {
+            if (!Enum.IsDefined(typeof(SupportedAlgorithms), algorithmToUse))
+                throw new ArgumentException("Invalid algorithm");
+
+            this.algorithmName = algorithmToUse.ToString();
+        }
+
+        /// <summary>
+        /// Computes the hash value for the specified data.
+        /// </summary>
+        internal byte[] ComputeHash(byte[] data)
+        {
+            if (data == null || data.Length == 0)
+                throw new ArgumentException("Invalid data to hash");
+#if NET452
+            using (var hashAlgorithm = HashAlgorithm.Create(this.algorithmName))
+            {
+                return hashAlgorithm.ComputeHash(data);
+            }
+#elif NETSTANDARD1_6
+            using (var hashAlgorithm = HashAlgoirthmFactory.Create(this.algorithmName))
+            {
+                return hashAlgorithm.ComputeHash(data);
+            }
+#endif 
+        }
+
+        /// <summary>
+        /// Returns true, if the computed hash value for the specified data matches the specified hash.
+        /// Matching is done constant-time to prevent time-based analysis.
+        /// </summary>
+        internal bool IsValidHash(byte[] data, byte[] incomingHash)
+        {
+            byte[] computedHash = this.ComputeHash(data);
+
+            return computedHash.IsConstantTimeEqualTo(incomingHash);
+        }
+
+        /// <summary>
+        /// Computes the keyed hash value (HMAC) for the specified data.
+        /// </summary>
+        internal byte[] ComputeHmac(byte[] data, byte[] key)
+        {
+            if (data == null || data.Length == 0)
+                throw new ArgumentException("Invalid data to hash");
+
+            if (key == null)
+                throw new ArgumentException("Invalid key");
+#if NET452
+            using (var algorithm = KeyedHashAlgorithm.Create("hmac" + this.algorithmName))
+            {
+                algorithm.Key = key;
+                return algorithm.ComputeHash(data);
+            }
+#elif NETSTANDARD1_6
+            using (var hashAlgorithm = HashAlgoirthmFactory.Create("hmac" + this.algorithmName))
+            {
+                return hashAlgorithm.ComputeHash(data);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Returns true, if the computed HMAC for the specified data matches the specified HMAC.
+        /// Matching is done constant-time to prevent time-based analysis.
+        /// </summary>
+        internal bool IsValidMac(byte[] data, byte[] key, byte[] incomingMac)
+        {
+            byte[] computedMac = this.ComputeHmac(data, key);
+
+            return computedMac.IsConstantTimeEqualTo(incomingMac);
+        }
+    }
+}

--- a/src/Hawk/Core/Helpers/HawkConstants.cs
+++ b/src/Hawk/Core/Helpers/HawkConstants.cs
@@ -1,0 +1,39 @@
+﻿
+namespace Thinktecture.IdentityModel.Hawk.Core.Helpers
+{
+    /// <summary>
+    /// Global constants
+    /// </summary>
+    public static class HawkConstants
+    {
+        /// <summary>"hawk"</summary>
+        public const string Scheme = "hawk";
+        
+        /// <summary>"1"</summary>
+        public const string Version = "1";
+
+        /// <summary>"Server-Authorization"</summary>
+        public const string ServerAuthorizationHeaderName = "Server-Authorization";
+
+        /// <summary>"WWW-Authenticate"</summary>
+        public const string WwwAuthenticateHeaderName = "WWW-Authenticate";
+
+		/// <summary>"Content-Type"</summary>
+        public const string ContentTypeHeaderName = "Content-Type";
+
+        /// <summary>"Authorization"</summary>
+        public const string AuthorizationHeaderName = "Authorization";
+
+        /// <summary>"bewit"</summary>
+        public const string Bewit = "bewit";
+    }
+
+    /// <summary>
+    /// The hashing algorithms currently supported by this implementation.
+    /// </summary>
+    public enum SupportedAlgorithms
+    {
+        SHA1,
+        SHA256
+    }
+}

--- a/src/Hawk/Core/Helpers/NonceGenerator.cs
+++ b/src/Hawk/Core/Helpers/NonceGenerator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+
+
+namespace Thinktecture.IdentityModel.Hawk.Core.Helpers
+{
+    /// <summary>
+    /// Generates a nonce to be used by a .NET client.
+    /// </summary>
+    public class NonceGenerator
+    {
+        private static readonly RandomNumberGenerator s_RnGenerator = RandomNumberGenerator.Create();
+
+        /// <summary>
+        /// Generates a nonce matching the specified length and returns the same. Default length is 6.
+        /// </summary>
+        public static string Generate(int length = 6)
+        {
+            var random = new List<char>();
+
+            do
+            {
+                byte[] bytes = new byte[length * 8];
+                s_RnGenerator.GetBytes(bytes);
+
+                var characters = bytes.Where(b => (b >= 48 && b <= 57) ||       // 0 - 9
+                                                    (b >= 97 && b <= 122) ||    // a - z
+                                                    (b >= 65 && b <= 90))       // A - Z
+                    .Take(length - random.Count)
+                    .Select(b => Convert.ToChar(b));
+
+                random.AddRange(characters);
+            }
+            while (random.Count < length);
+
+            return new string(random.ToArray());
+        }
+    }
+}

--- a/src/Hawk/Core/MessageContracts/IMessage.cs
+++ b/src/Hawk/Core/MessageContracts/IMessage.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.MessageContracts
+{
+    /// <summary>
+    /// Represents the elements of an HTTP message common to both request and response.
+    /// </summary>
+    public interface IMessage
+    {
+        /// <summary>
+        /// Message body
+        /// </summary>
+        Task<string> ReadBodyAsStringAsync();
+
+        /// <summary>
+        /// Content type of the message body, if any.
+        /// </summary>
+        string ContentType { get; }
+
+        /// <summary>
+        /// Message headers
+        /// </summary>
+        IDictionary<string, string[]> Headers { get; }
+    }
+}

--- a/src/Hawk/Core/MessageContracts/IRequestMessage.cs
+++ b/src/Hawk/Core/MessageContracts/IRequestMessage.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.MessageContracts
+{
+    /// <summary>
+    /// Represents an HTTP Request message applicable to Hawk authentication.
+    /// </summary>
+    public interface IRequestMessage : IMessage
+    {
+        /// <summary>
+        /// Per-request placeholder for the challenge parameter
+        /// </summary>
+        string ChallengeParameter { get; set; }
+
+        /// <summary>
+        /// Host header value
+        /// </summary>
+        string Host { get; }
+
+		/// <summary>
+        /// Authorization header value
+        /// </summary>
+        AuthenticationHeaderValue Authorization { get; set; }
+
+        /// <summary>
+        /// Request URI
+        /// </summary>
+        Uri Uri { get; }
+
+        /// <summary>
+        /// Query string setter for setting query string sans bewit.
+        /// </summary>
+        string QueryString { set; }
+
+        /// <summary>
+        /// HTTP Method
+        /// </summary>
+        HttpMethod Method { get; }
+
+        /// <summary>
+        /// HTTP Request Scheme
+        /// </summary>
+        string Scheme { get; }
+    }
+}

--- a/src/Hawk/Core/MessageContracts/IResponseMessage.cs
+++ b/src/Hawk/Core/MessageContracts/IResponseMessage.cs
@@ -1,0 +1,28 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+
+namespace Thinktecture.IdentityModel.Hawk.Core.MessageContracts
+{
+    /// <summary>
+    /// Represents an HTTP response message applicable to Hawk authentication.
+    /// </summary>
+    public interface IResponseMessage : IMessage
+    {
+        /// <summary>
+        /// Status code
+        /// </summary>
+        HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// WwwAuthenticate header value
+        /// </summary>
+        AuthenticationHeaderValue WwwAuthenticate { get; }
+
+        /// <summary>
+        /// Adds a header to response message
+        /// </summary>
+        /// <param name="name">header name</param>
+        /// <param name="value">header value</param>
+        void AddHeader(string name, string value);
+    }
+}

--- a/src/Hawk/Core/NormalizedPayload.cs
+++ b/src/Hawk/Core/NormalizedPayload.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Text;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Represents the normalized payload, in the following format.
+    /// hawk.1.payload\n
+    /// content type\n
+    /// body content\n
+    /// </summary>
+    internal class NormalizedPayload
+    {
+        private const string PREAMBLE = HawkConstants.Scheme + "." + HawkConstants.Version + ".payload"; // hawk.1.payload
+
+        private readonly string body = null;
+        private readonly string contentType = null;
+
+        internal NormalizedPayload(string body, string contentType)
+        {
+            this.body = body;
+            this.contentType = contentType;
+        }
+
+        /// <summary>
+        /// Returns the normalized payload bytes.
+        /// </summary>
+        internal byte[] ToBytes()
+        {
+            if (this.body != null)
+            {
+                StringBuilder builder = new StringBuilder();
+
+                builder
+                    .AppendNewLine(PREAMBLE)
+                    .AppendNewLine(contentType == null ? String.Empty : contentType.ToLower())
+                    .AppendNewLine(this.body);
+
+                string normalizedPayload = builder.ToString();
+
+                HawkEventSource.Log.NormalizedBody(normalizedPayload);
+
+                return normalizedPayload.ToBytesFromUtf8();
+            }
+
+            HawkEventSource.Log.NormalizedBody("null");
+
+            return null;
+        }
+    }
+}

--- a/src/Hawk/Core/NormalizedRequest.cs
+++ b/src/Hawk/Core/NormalizedRequest.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Represents the normalized request, in the following format.
+    /// hawk.1.header\n
+    /// timestamp\n
+    /// nonce\n
+    /// HTTP method\n
+    /// uri path and query string\n
+    /// host name\n
+    /// port\n
+    /// payload hash\n
+    /// application specific data\n
+    /// </summary>
+    internal class NormalizedRequest
+    {
+        private const string REQUEST_PREAMBLE = HawkConstants.Scheme + "." + HawkConstants.Version + ".header"; // hawk.1.header
+        private const string BEWIT_PREAMBLE = HawkConstants.Scheme + "." + HawkConstants.Version + ".bewit"; // hawk.1.bewit
+        private const string RESPONSE_PREAMBLE = HawkConstants.Scheme + "." + HawkConstants.Version + ".response"; // hawk.1.response
+
+        private readonly ArtifactsContainer artifacts = null;
+
+        private readonly string method = null;
+        private readonly string path = null;
+        private readonly string hostName = null;
+        private readonly string port = null;
+
+        internal NormalizedRequest(IRequestMessage request, ArtifactsContainer artifacts, string hostName = null, string port = null)
+        {
+            this.artifacts = artifacts;
+
+            this.hostName = (hostName ?? request.Uri.Host).ToLower();
+            this.port = port ?? request.Uri.Port.ToString();
+            this.method = request.Method.Method.ToUpper();
+            this.path = WebUtility.UrlDecode(request.Uri.AbsolutePath) + request.Uri.Query;
+        }
+
+        /// <summary>
+        /// Set to true, if this instance is for a bewit.
+        /// </summary>
+        internal bool IsBewit { get; set; }
+
+        /// <summary>
+        /// Set to true, if this instance is for server authorization response.
+        /// </summary>
+        internal bool IsServerAuthorization { get; set; }
+
+        /// <summary>
+        /// Returns the normalized request string.
+        /// </summary>
+        public override string ToString()
+        {
+            StringBuilder result = new StringBuilder();
+            result
+                .AppendNewLine(this.GetPreamble())
+                .AppendNewLine(artifacts.Timestamp.ToString())
+                .AppendNewLine(artifacts.Nonce)
+                .AppendNewLine(this.method)
+                .AppendNewLine(this.path)
+                .AppendNewLine(this.hostName)
+                .AppendNewLine(this.port)
+                .AppendNewLine(artifacts.PayloadHash == null ? null : artifacts.PayloadHash.ToBase64String())
+                .AppendNewLine(artifacts.ApplicationSpecificData);
+
+            string normalizedRequest = result.ToString();
+
+            HawkEventSource.Log.NormalizedRequest(normalizedRequest);
+
+            return normalizedRequest;
+        }
+
+        /// <summary>
+        /// Returns the normalized request bytes.
+        /// </summary>
+        internal byte[] ToBytes()
+        {
+            return this.ToString().ToBytesFromUtf8();
+        }
+
+        private string GetPreamble()
+        {
+            string preamble = REQUEST_PREAMBLE;
+            if (this.IsBewit)
+                preamble = BEWIT_PREAMBLE;
+            else if (this.IsServerAuthorization)
+                preamble = RESPONSE_PREAMBLE;
+
+            return preamble;
+        }
+    }
+}

--- a/src/Hawk/Core/NormalizedTimestamp.cs
+++ b/src/Hawk/Core/NormalizedTimestamp.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Normalized representation of the timestamp data to be sent in the WWW-Authenticate header,
+    /// when authentication failed on account of stale timestamp sent in by the client.
+    /// hawk.1.ts\n
+    /// timestamp\n
+    /// </summary>
+    internal class NormalizedTimestamp
+    {
+        private const string PREAMBLE = HawkConstants.Scheme + "." + HawkConstants.Version + ".ts"; // hawk.1.ts
+        private const string TS = "ts";
+        private const string TSM = "tsm";
+
+        private readonly ulong unixTimeMillis;
+        private readonly Credential credential;
+
+        private readonly double fresh;
+
+        internal NormalizedTimestamp(ulong unixTime, Credential credential, int localOffset = 0)
+        {
+            this.unixTimeMillis = unixTime * 1000;
+            this.credential = credential;
+
+            fresh = Math.Floor((this.unixTimeMillis + Convert.ToUInt64(localOffset)) / 1000.0);
+        }
+
+        internal NormalizedTimestamp(DateTime utcNow, Credential credential, int localOffset = 0) :
+            this(utcNow.ToUnixTime(), credential, localOffset) { }
+
+        /// <summary>
+        /// Returns the normalized representation of the timestamp data.
+        /// </summary>
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.AppendNewLine(PREAMBLE)
+                .AppendNewLine(fresh.ToString());
+
+            string normalizedTimestamp = builder.ToString();
+
+            HawkEventSource.Log.NormalizedTimestamp(normalizedTimestamp);
+
+            return normalizedTimestamp;
+        }
+
+        /// <summary>
+        /// Returns true, if the HMAC calculated for the normalized representation of the timestamp data that
+        /// this instance represents matches the passed in HMAC.
+        /// </summary>
+        internal bool IsValid(byte[] hmacToValidateAgainst)
+        {
+            Hasher hasher = new Hasher(credential.Algorithm);
+            byte[] computedMac = hasher.ComputeHmac(this.ToString().ToBytesFromUtf8(), credential.Key);
+
+            // Okay not to use the constant-time comparison, since the timestamp
+            // HMAC validation is done in the client side
+            return computedMac.SequenceEqual(hmacToValidateAgainst);
+        }
+
+        /// <summary>
+        /// Returns the header parameter to be put into the HTTP WWW-Authenticate header. The field ts has the timestamp
+        /// in UNIX time corresponding to the server clock and the field tsm is the MAC calculated for the normalized
+        /// timestamp data using the shared symmetric key and the algorithm agreed upon.
+        /// </summary>
+        /// <returns></returns>
+        internal string ToWwwAuthenticateHeaderParameter()
+        {
+            Hasher hasher = new Hasher(credential.Algorithm);
+
+            byte[] data = this.ToString().ToBytesFromUtf8();
+
+            string tsm = hasher.ComputeHmac(data, credential.Key).ToBase64String();
+
+            char trailer = ',';
+
+            StringBuilder result = new StringBuilder();
+            result.AppendIfNotEmpty(TS, fresh.ToString(), trailer)
+                .AppendIfNotEmpty(TSM, tsm, trailer);
+
+            return result.ToString().Trim().Trim(trailer);
+        }
+    }
+}

--- a/src/Hawk/Core/Options.cs
+++ b/src/Hawk/Core/Options.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+using Thinktecture.IdentityModel.Hawk.Core.Extensions;
+using Thinktecture.IdentityModel.Hawk.Etw;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Thinktecture.IdentityModel.Hawk.Core
+{
+    /// <summary>
+    /// Hawk authentication options.
+    /// </summary>
+    public class Options
+    {
+        public Options()
+        {
+            this.ClockSkewSeconds = 60;
+            this.EnableServerAuthorization = true;
+            this.DetermineHostDetailsCallback = DefaultBehavior.DetermineHostDetails;
+            this.DetermineNonceReplayCallback = DefaultBehavior.GetLastUsedId;
+            this.StoreNonceCallback = DefaultBehavior.StoreNonce;
+        }
+
+        /// <summary>
+        /// Local time offset in milliseconds.
+        /// </summary>
+        public int LocalTimeOffsetMillis { get; set; }
+
+        /// <summary>
+        /// Skew allowed between the client and the server clocks in seconds. Default is 60 seconds.
+        /// </summary>
+        public int ClockSkewSeconds { get; set; }
+
+        /// <summary>
+        /// If true, the Server-Authorization header is sent in the response. Default is true.
+        /// </summary>
+        public bool EnableServerAuthorization { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns Credential for the given user identifier.
+        /// </summary>
+        public Func<string, Credential> CredentialsCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns the normalized form of the response message to be used
+        /// as application specific data ('ext' field) in the Server-Authorization response header.
+        /// </summary>
+        public Func<IResponseMessage, string> NormalizationCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns true if the specified normalized form of the request
+        /// message matches the normalized form of the specified request message.
+        /// </summary>
+        public Func<IRequestMessage, string, bool> VerificationCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns true, if the response body must be hashed and included
+        /// in the MAC ('mac' field) sent in the Server-Authorization response header.
+        /// </summary>
+        public Func<IRequestMessage, bool> ResponsePayloadHashabilityCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns the host name and port number.
+        /// </summary>
+        public Func<IRequestMessage, Tuple<string, string>> DetermineHostDetailsCallback { get; set; }
+
+        /// <summary>
+        /// Action delegate that stores the nonce from the request for a specific period to 
+        /// detect replay of old requests, against the identifier.
+        /// </summary>
+        public Action<string, string, int> StoreNonceCallback { get; set; }
+
+        /// <summary>
+        /// Func delegate that returns the identifier used with an earlier request,
+        /// if a nonce was replayed. Returns null, if nonce is fresh.
+        /// By default, the nonce values from the requests are stored in the memory in-proc.
+        /// If you use multiple servers or processes for load balancing and if the replay
+        /// request goes to a server that did not service the request before, nonce will not
+        ///  be rejected. In such cases, store the nonce as part of StoreNonceCallback into a
+        ///  store common to all instances and check the nonce as part of this callback.
+        /// </summary>
+        public Func<string, string> DetermineNonceReplayCallback { get; set; }
+
+        public class DefaultBehavior
+        {
+            static readonly object cacheLock = new object();
+            static readonly Lazy<MemoryCache> s_DefaultCache = new Lazy<MemoryCache>(() => new MemoryCache(new MemoryCacheOptions())); 
+
+            internal static Tuple<string, string> DetermineHostDetails(IRequestMessage request)
+            {
+                string host = request.Headers.FirstOrDefault("X-Forwarded-Host");
+
+                HawkEventSource.Log.Debug("X-Forwarded-Host=" + (host ?? String.Empty));
+
+                if (String.IsNullOrWhiteSpace(host))
+                    host = request.Host;
+
+                HawkEventSource.Log.Debug("Host=" + (host ?? String.Empty));
+
+                if (String.IsNullOrWhiteSpace(host))
+                    host = request.Uri.Host;
+
+                string hostName = String.Empty;
+                string port = String.Empty;
+
+                string pattern = @"^(?:(?:\r\n)?\s)*((?:[^:]+)|(?:\[[^\]]+\]))(?::(\d+))?(?:(?:\r\n)?\s)*$";
+                var match = Regex.Match(host, pattern);
+
+                if (match.Success && match.Groups.Count == 3)
+                {
+                    hostName = match.Groups[1].Value;
+
+                    if (!String.IsNullOrWhiteSpace(hostName))
+                    {
+                        port = match.Groups[2].Value;
+                    }
+                }
+
+                if (String.IsNullOrWhiteSpace(port))
+                {
+                    port = request.Headers.FirstOrDefault("X-Forwarded-Port");
+
+                    HawkEventSource.Log.Debug("X-Forwarded-Port=" + (port ?? String.Empty));
+                }
+
+                if (String.IsNullOrWhiteSpace(port))
+                {
+                    string scheme = request.Headers.FirstOrDefault("X-Forwarded-Proto");
+
+                    HawkEventSource.Log.Debug("X-Forwarded-Proto=" + (scheme ?? String.Empty));
+
+                    if (String.IsNullOrWhiteSpace(scheme))
+                    {
+                        scheme = request.Scheme;
+                    }
+
+                    port = "https".Equals(scheme, StringComparison.OrdinalIgnoreCase) ? "443" : "80";
+
+                    HawkEventSource.Log.Debug("Port chosen based on HTTP scheme: " + port);
+                }
+
+                return new Tuple<string, string>(hostName, port);
+            }
+
+            internal static void StoreNonce(string nonce, string id, int lifeSeconds)
+            {
+                var options = new MemoryCacheEntryOptions()
+                    .SetAbsoluteExpiration(new DateTimeOffset(DateTime.Now.AddSeconds(lifeSeconds)));
+                lock (cacheLock)
+                {
+                    s_DefaultCache.Value.Set(nonce, id, options);
+                }
+            }
+
+            internal static string GetLastUsedId(string nonce)
+            {
+                return s_DefaultCache.Value.Get(nonce) as string;
+            }
+        }
+    }
+}

--- a/src/Hawk/Etw/HawkEventSource.cs
+++ b/src/Hawk/Etw/HawkEventSource.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Thinktecture.IdentityModel.Hawk.Etw
+{
+    [EventSource(Name = "Thinktecture-IdentityModel-Hawk-Etw-HawkEventSource")]
+    public class HawkEventSource : EventSource
+    {
+        private static readonly Lazy<HawkEventSource> source = new Lazy<HawkEventSource>(() => new HawkEventSource());
+
+        private HawkEventSource() { }
+
+        public static HawkEventSource Log
+        {
+            get
+            {
+                return source.Value;
+            }
+        }
+
+        [Event(1, Keywords = Keywords.Common, Level = EventLevel.Verbose)]
+        public void Debug(string Message)
+        {
+            if (this.IsEnabled()) this.WriteEvent(1, Message);
+        }
+
+        [Event(2, Keywords = Keywords.Common, Level = EventLevel.Informational)]
+        public void NormalizedTimestamp(string NormalizedFormat)
+        {
+            if (this.IsEnabled()) this.WriteEvent(2, NormalizedFormat);
+        }
+
+        [Event(3, Keywords = Keywords.Common, Level = EventLevel.Informational)]
+        public void UnparsedArtifact(string Unparsed)
+        {
+            if (this.IsEnabled()) this.WriteEvent(3, Unparsed);
+        }
+
+        [Event(4, Keywords = Keywords.Common, Level = EventLevel.Informational)]
+        public void NormalizedBody(string NormalizedFormat)
+        {
+            if (this.IsEnabled()) this.WriteEvent(4, NormalizedFormat);
+        }
+
+        [Event(5, Keywords = Keywords.Common, Level = EventLevel.Informational)]
+        public void StaleTimestamp(string Age, string ShelfLife)
+        {
+            if (this.IsEnabled()) this.WriteEvent(5, Age, ShelfLife);
+        }
+
+        [Event(6, Keywords = Keywords.Common, Level = EventLevel.Informational)]
+        public void NormalizedRequest(string NormalizedFormat)
+        {
+            if (this.IsEnabled()) this.WriteEvent(6, NormalizedFormat);
+        }
+
+        [Event(7, Keywords = Keywords.Common, Level = EventLevel.Error)]
+        public void Exception(string Message)
+        {
+            if (this.IsEnabled()) this.WriteEvent(7, Message);
+        }
+
+        [Event(8, Keywords = Keywords.Client, Level = EventLevel.Informational)]
+        public void TimestampMismatch(int CompensatorySeconds)
+        {
+            if (this.IsEnabled()) this.WriteEvent(8, CompensatorySeconds);
+        }
+
+        [Event(9, Keywords = Keywords.Client, Level = EventLevel.Informational)]
+        public void ServerResponse(int StatusCode, string Body, string AuthorizationHeader)
+        {
+            if (this.IsEnabled()) this.WriteEvent(9, StatusCode, Body, AuthorizationHeader);
+        }
+
+        [Event(10, Keywords = Keywords.Common, Level = EventLevel.Warning)]
+        public void NonceReplay(string Nonce, string LastUsedBy)
+        {
+            if (this.IsEnabled()) this.WriteEvent(10, Nonce, LastUsedBy);
+        }
+
+        public class Keywords
+        {
+            public const EventKeywords Common = (EventKeywords)1;
+            public const EventKeywords Middleware = (EventKeywords)2;
+            public const EventKeywords Client = (EventKeywords)4;
+        }
+    }
+}

--- a/src/Hawk/Hawk.xproj
+++ b/src/Hawk/Hawk.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>8fe4c35e-e9b5-4968-aa4c-fad1e0db8be3</ProjectGuid>
+    <RootNamespace>Hawk</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Hawk/Middleware/Extensions/HawkAuthenticationExtension.cs
+++ b/src/Hawk/Middleware/Extensions/HawkAuthenticationExtension.cs
@@ -1,0 +1,27 @@
+﻿#if NETSTANDARD1_6
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Builder;
+#elif NET452
+using Microsoft.Owin.Extensions;
+using Owin;
+#endif
+
+namespace Hawk.Middleware.Extensions
+{
+    public static class HawkAuthenticationExtension
+    {
+
+
+#if NETSTANDARD1_6
+  
+
+#elif NET452
+        public static IAppBuilder UseHawkAuthentication(this IAppBuilder app, HawkAuthenticationOptions options)
+        {
+            app.Use(typeof(HawkAuthenticationMiddleware), app, options);
+            app.UseStageMarker(PipelineStage.Authenticate);
+            return app;
+        }
+#endif
+    }
+}

--- a/src/Hawk/Middleware/Extensions/OwinRequestExtension.cs
+++ b/src/Hawk/Middleware/Extensions/OwinRequestExtension.cs
@@ -1,0 +1,28 @@
+﻿#if NET452
+using Microsoft.Owin;
+#endif
+using System;
+using System.Net.Http.Headers;
+using Thinktecture.IdentityModel.Hawk.Core;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+
+namespace Hawk.Middleware.Extensions
+{
+#if NET452
+    internal static class OwinRequestExtension
+    {
+        internal static bool IsPayloadHashPresent(this IOwinRequest request)
+        {
+            string authorization = request.Headers.Get(HawkConstants.AuthorizationHeaderName);
+
+            if (!String.IsNullOrWhiteSpace(authorization))
+            {
+                string parameter = AuthenticationHeaderValue.Parse(authorization).Parameter;
+                return ArtifactsContainer.IsPayloadHashPresent(parameter);
+            }
+
+            return false;
+        }
+    }
+#endif
+}

--- a/src/Hawk/Middleware/HashAlgoirthmFactory.cs
+++ b/src/Hawk/Middleware/HashAlgoirthmFactory.cs
@@ -1,0 +1,57 @@
+﻿#if NETSTANDARD1_6
+
+using System.Security.Cryptography;
+
+namespace Hawk.Middleware
+{
+    public class HashAlgoirthmFactory
+    {
+        public static HashAlgorithm Create(string hashAlgorithmName)
+        {
+            if (hashAlgorithmName == HashAlgorithmName.MD5.Name)
+            {
+                return MD5.Create();
+            }
+            else if (hashAlgorithmName == "hmac" + HashAlgorithmName.MD5.Name)
+            {
+                return new HMACMD5();
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA1.Name)
+            {
+                return SHA1.Create();
+            }
+            else if (hashAlgorithmName == "hmac" + HashAlgorithmName.SHA1.Name)
+            {
+                return new HMACSHA1();
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA256.Name)
+            {
+                return SHA256.Create();
+            }
+            else if (hashAlgorithmName == "hmac" + HashAlgorithmName.SHA256.Name)
+            {
+                return new HMACSHA256(); 
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA384.Name)
+            {
+                return SHA384.Create();
+            }
+            else if (hashAlgorithmName == "hmac" + HashAlgorithmName.SHA384.Name)
+            {
+                return new HMACSHA384();
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA512.Name)
+            {
+                return SHA512.Create();
+            }
+            else if (hashAlgorithmName == "hmac" + HashAlgorithmName.SHA512.Name)
+            {
+                return new HMACSHA512(); 
+            }
+
+            return null;
+
+        }
+    }
+}
+#endif

--- a/src/Hawk/Middleware/HawkAuthenticationHandler.cs
+++ b/src/Hawk/Middleware/HawkAuthenticationHandler.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.IO;
+using System.Security.Claims;
+using System.Threading.Tasks;
+#if NETSTANDARD1_6
+using Microsoft.AspNetCore.Http.Authentication;
+#elif NET452
+using Microsoft.Owin.Security.Infrastructure;
+using Microsoft.Owin.Security;
+#endif
+using Thinktecture.IdentityModel.Hawk.Core;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+using Thinktecture.IdentityModel.Hawk.Etw;
+using Hawk.Middleware.Extensions;
+
+namespace Hawk.Middleware
+{
+#if NETSTANDARD1_6
+#elif NET452
+    public class HawkAuthenticationHandler : AuthenticationHandler<HawkAuthenticationOptions>
+    {
+        private HawkServer server = null;
+        private Stream stream = null;
+        private MemoryStream requestBuffer = null, responseBuffer = null;
+
+        protected async override Task<AuthenticationTicket> AuthenticateCoreAsync()
+        {
+            try
+            {
+                if (Request.IsPayloadHashPresent())
+                {
+                    // buffer the request body
+                    requestBuffer = new MemoryStream();
+                    await Request.Body.CopyToAsync(requestBuffer);
+                    Request.Body = requestBuffer;
+                }
+
+                IRequestMessage requestMessage = new OwinRequestMessage(Request);
+
+                server = new HawkServer(requestMessage, Options.HawkOptions);
+
+                var principal = await server.AuthenticateAsync();
+
+                if (principal != null && principal.Identity.IsAuthenticated)
+                {
+                    if (!server.IsBewitRequest) // Bewit means no server authorization and hence no need for buffering.
+                    {
+                        var callback = Options.HawkOptions.ResponsePayloadHashabilityCallback;
+
+                        if (callback != null && callback(requestMessage)) // buffer the response body
+                        {
+                            stream = Response.Body;
+                            responseBuffer = new MemoryStream();
+                            Response.Body = responseBuffer;
+
+                            HawkEventSource.Log.Debug("Response Body Buffered");
+                        }
+                    }
+
+                    return new AuthenticationTicket(principal.Identity as ClaimsIdentity, (AuthenticationProperties)null);
+                }
+            }
+            catch (Exception exception)
+            {
+                HawkEventSource.Log.Exception(exception.ToString());
+
+                if (responseBuffer != null)
+                {
+                    Response.Body = this.stream;
+                }
+
+                throw;
+            }
+
+            return new AuthenticationTicket(null, (AuthenticationProperties)null);
+        }
+
+        protected override async Task TeardownCoreAsync()
+        {
+            if (responseBuffer != null)
+            {
+                responseBuffer.Seek(0, SeekOrigin.Begin);
+                await responseBuffer.CopyToAsync(stream); // Write buffer onto the stream ...
+
+                // ... and switch back to the original stream
+                Response.Body = this.stream;
+
+                HawkEventSource.Log.Debug("Response Body UnBuffered");
+            }
+        }
+
+        protected override async Task ApplyResponseChallengeAsync()
+        {
+            // In case of 401, we do not add WWW-Authenticate, if authentication mode is passive.
+            if (Response.StatusCode == 401)
+            {
+                var challenge = Helper.LookupChallenge(Options.AuthenticationType, Options.AuthenticationMode);
+
+                if (challenge == null)
+                {
+                    return;
+                }
+            }
+
+            IResponseMessage responseMessage = new OwinResponseMessage(Response);
+
+            var header = await server.CreateServerAuthorizationAsync(responseMessage);
+
+            if (header != null)
+                responseMessage.AddHeader(header.Item1, header.Item2);
+        }
+    }
+#endif
+}

--- a/src/Hawk/Middleware/HawkAuthenticationMiddleware.cs
+++ b/src/Hawk/Middleware/HawkAuthenticationMiddleware.cs
@@ -1,0 +1,43 @@
+﻿
+using System.Threading.Tasks;
+#if NETSTANDARD1_6
+using Microsoft.AspNetCore.Http;
+#elif NET452
+using Owin;
+using Microsoft.Owin;
+using Microsoft.Owin.Security.Infrastructure;
+#endif
+
+namespace Hawk.Middleware
+{
+#if NETSTANDARD1_6
+    public class HawkAuthenticationMiddleware
+    {
+        private readonly RequestDelegate next;
+
+        public HawkAuthenticationMiddleware(RequestDelegate next)
+        {
+            this.next = next;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+  
+            return this.next(context);
+        }
+
+    }
+#elif NET452
+    public class HawkAuthenticationMiddleware : AuthenticationMiddleware<HawkAuthenticationOptions>
+    {
+        public HawkAuthenticationMiddleware(OwinMiddleware next, IAppBuilder app, HawkAuthenticationOptions options)
+            : base(next, options)
+        { }
+
+        protected override AuthenticationHandler<HawkAuthenticationOptions> CreateHandler()
+        {
+            return new HawkAuthenticationHandler();
+        }
+    }
+#endif
+}

--- a/src/Hawk/Middleware/HawkAuthenticationOptions.cs
+++ b/src/Hawk/Middleware/HawkAuthenticationOptions.cs
@@ -1,0 +1,22 @@
+﻿#if NET452
+using Microsoft.Owin.Security;
+#endif
+using Thinktecture.IdentityModel.Hawk.Core;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+
+namespace Hawk.Middleware
+{
+#if NETSTANDARD1_6
+#elif NET452
+    public class HawkAuthenticationOptions : AuthenticationOptions
+    {
+        public HawkAuthenticationOptions(Options hawkOptions)
+            : base(HawkConstants.Scheme)
+        {
+            this.HawkOptions = hawkOptions;
+        }
+
+        public Options HawkOptions { get; set; }
+    }
+#endif
+}

--- a/src/Hawk/Middleware/OwinMessage.cs
+++ b/src/Hawk/Middleware/OwinMessage.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hawk.Middleware
+{
+#if NET452
+
+    public abstract class OwinMessage
+    {
+        private readonly Encoding defaultEncoding = Encoding.UTF8;
+        private readonly Lazy<string> body = null;
+
+        public OwinMessage(Stream bodyStream, string contentType)
+        {
+            this.body = new Lazy<string>(() =>
+            {
+                MemoryStream buffer = bodyStream as MemoryStream;
+
+                if (buffer != null)
+                {
+                    byte[] content = buffer.GetBuffer();
+                    if (content != null && content.Length > 0)
+                    {
+                        Encoding encoding = GetEncodingForContentType(contentType);
+                        string body = encoding.GetString(content, 0, (int)buffer.Length);
+
+                        buffer.Seek(0, SeekOrigin.Begin);
+
+                        return body;
+                    }
+                }
+
+                return null;
+            });
+        }
+
+        /// <summary>
+        /// Returns the Encoding object for the charset in the Content-Type header value.
+        /// </summary>
+        /// <param name="contentType"></param>
+        /// <returns></returns>
+        private Encoding GetEncodingForContentType(string contentType)
+        {
+            Encoding encoding = defaultEncoding;
+
+            if (!String.IsNullOrWhiteSpace(contentType))
+            {
+                var mediaHeader = MediaTypeHeaderValue.Parse(contentType);
+                if (mediaHeader != null)
+                {
+                    string charset = mediaHeader.CharSet;
+                    if (!String.IsNullOrWhiteSpace(charset))
+                        encoding = Encoding.GetEncoding(charset);
+                }
+            }
+
+            return encoding;
+        }
+
+        public Task<string> ReadBodyAsStringAsync()
+        {
+            return Task.FromResult<string>(this.body.Value);
+        }
+    }
+#endif
+}

--- a/src/Hawk/Middleware/OwinRequestMessage.cs
+++ b/src/Hawk/Middleware/OwinRequestMessage.cs
@@ -1,0 +1,123 @@
+﻿#if NET452
+using Microsoft.Owin;
+#endif
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+namespace Hawk.Middleware
+{
+#if NET452
+    public class OwinRequestMessage : OwinMessage, IRequestMessage
+    {
+        private const string PARAMETER_KEY = "HK_Challenge";
+        private const string OwinRequestHeadersKey = "owin.RequestHeaders";
+
+        private IOwinRequest request;
+
+        public OwinRequestMessage(IOwinRequest request)
+            : base(request.Body, request.Headers.Get(HawkConstants.ContentTypeHeaderName))
+        {
+            this.request = request;
+        }
+
+        public string ChallengeParameter
+        {
+            get
+            {
+                return this.request.Get<string>(PARAMETER_KEY);
+            }
+            set
+            {
+                this.request.Set<string>(PARAMETER_KEY, value);
+            }
+        }
+
+        public string Host
+        {
+            get
+            {
+                return this.request.Host.Value;
+            }
+        }
+
+        public AuthenticationHeaderValue Authorization
+        {
+            get
+            {
+                string authorization = this.request.Headers.Get(HawkConstants.AuthorizationHeaderName);
+
+                return authorization != null ?
+                    AuthenticationHeaderValue.Parse(authorization) :
+                        null;
+            }
+            set
+            {
+                this.Headers[HawkConstants.AuthorizationHeaderName] = new[] { value.ToString() };
+            }
+        }
+
+        public Uri Uri
+        {
+            get
+            {
+                return this.request.Uri;
+            }
+        }
+
+        public HttpMethod Method
+        {
+            get
+            {
+                return new HttpMethod(this.request.Method);
+            }
+        }
+
+        public string ContentType
+        {
+            get
+            {
+                string contentType = this.request.Headers.Get(HawkConstants.ContentTypeHeaderName);
+
+                if (!String.IsNullOrWhiteSpace(contentType))
+                {
+                    var header = MediaTypeHeaderValue.Parse(contentType);
+                    if (header != null)
+                        return header.MediaType;
+                }
+
+                return null;
+            }
+        }
+
+        public IDictionary<string, string[]> Headers
+        {
+            get
+            {
+                return this.request.Environment[OwinRequestHeadersKey] as IDictionary<string, string[]>;
+            }
+        }
+
+        public string QueryString
+        {
+            set
+            {
+                this.request.QueryString = value == null ?
+                                                Microsoft.Owin.QueryString.Empty :
+                                                    new Microsoft.Owin.QueryString(value);
+            }
+        }
+
+        public string Scheme
+        {
+            get
+            {
+                return this.request.Scheme;
+            }
+        }
+    }
+#endif
+}

--- a/src/Hawk/Middleware/OwinResponseMessage.cs
+++ b/src/Hawk/Middleware/OwinResponseMessage.cs
@@ -1,0 +1,83 @@
+﻿#if NET452
+using Microsoft.Owin;
+#endif
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+
+namespace Hawk.Middleware
+{
+#if NET452
+    public class OwinResponseMessage : OwinMessage, IResponseMessage
+    {
+        private const string OwinResponseHeadersKey = "owin.ResponseHeaders";
+
+        private IOwinResponse response;
+
+        public OwinResponseMessage(IOwinResponse response)
+            : base(response.Body, response.ContentType)
+        {
+            this.response = response;
+        }
+
+        public HttpStatusCode StatusCode
+        {
+            get
+            {
+                var statusCode = Enum.Parse(typeof(HttpStatusCode), this.response.StatusCode.ToString());
+                return (HttpStatusCode)statusCode;
+            }
+        }
+
+        public AuthenticationHeaderValue WwwAuthenticate
+        {
+            get
+            {
+                if (this.Headers.ContainsKey(HawkConstants.WwwAuthenticateHeaderName))
+                {
+                    string[] headerValues = this.Headers[HawkConstants.WwwAuthenticateHeaderName];
+                    string hawkHeader = headerValues.First(s => s.StartsWith(HawkConstants.Scheme,
+                                                                                StringComparison.OrdinalIgnoreCase));
+
+                    return AuthenticationHeaderValue.Parse(hawkHeader);
+                }
+
+                return null;
+            }
+        }
+
+        public void AddHeader(string name, string value)
+        {
+            this.response.Headers.AppendValues(name, value);
+        }
+
+        public string ContentType
+        {
+            get
+            {
+                string contentType = this.response.ContentType;
+                if (!String.IsNullOrWhiteSpace(contentType))
+                {
+                    var header = MediaTypeHeaderValue.Parse(contentType);
+                    return header.MediaType;
+                }
+
+                return null;
+            }
+        }
+
+        public IDictionary<string, string[]> Headers
+        {
+            get
+            {
+                return this.response.Environment[OwinResponseHeadersKey] as IDictionary<string, string[]>;
+            }
+        }
+    }
+#endif
+}

--- a/src/Hawk/Properties/AssemblyInfo.cs
+++ b/src/Hawk/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Thinktecture.IdentityModel.Hawk")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Thinktecture.IdentityModel.Hawk")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bc5472b1-dab2-4fb1-8de7-2bd2ef48a6f5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("HawkTests")]

--- a/src/Hawk/WebApi/HawkAuthenticationHandler.cs
+++ b/src/Hawk/WebApi/HawkAuthenticationHandler.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Thinktecture.IdentityModel.Hawk.Core;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Etw;
+
+namespace Thinktecture.IdentityModel.Hawk.WebApi
+{
+#if NET452
+    /// <summary>
+    /// The message handler that performs the authentication based on the authenticity of the HMAC.
+    /// Add a new instance of this handler to config.MessageHandlers in WebApiConfig.Register().
+    /// </summary>
+    public class HawkAuthenticationHandler : DelegatingHandler
+    {
+        private readonly Options options = null;
+
+        /// <summary>
+        /// The message handler that authenticates the request using Hawk.
+        /// </summary>
+        /// <param name="options">Hawk authentication options</param>
+        public HawkAuthenticationHandler(Options options)
+        {
+            if (options == null || options.CredentialsCallback == null)
+                throw new ArgumentNullException("Invalid Hawk authentication options. Credentials callback cannot be null.");
+
+            this.options = options;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+                                        HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                HawkServer server = new HawkServer(new WebApiRequestMessage(request), options);
+
+                var principal = await server.AuthenticateAsync();
+
+                if (principal != null && principal.Identity.IsAuthenticated)
+                {
+                    request.GetRequestContext().Principal = principal;
+
+                    HawkEventSource.Log.Debug("Authentication Successful and principal set for " + principal.Identity.Name);
+                }
+
+                var response = await base.SendAsync(request, cancellationToken);
+
+                var header = await server.CreateServerAuthorizationAsync(new WebApiResponseMessage(response));
+                if (header != null)
+                    response.Headers.Add(header.Item1, header.Item2);
+
+                return response;
+            }
+            catch (Exception exception)
+            {
+                HawkEventSource.Log.Exception(exception.ToString());
+
+                var response = request.CreateResponse(HttpStatusCode.Unauthorized);
+                response.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(HawkConstants.Scheme));
+
+                return response;
+            }
+        }
+    }
+#endif
+}

--- a/src/Hawk/WebApi/WebApiMessage.cs
+++ b/src/Hawk/WebApi/WebApiMessage.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+namespace Thinktecture.IdentityModel.Hawk.WebApi
+{
+    /// <summary>
+    /// The base HTTP message class.
+    /// </summary>
+    public abstract class WebApiMessage : IMessage
+    {
+        private readonly HttpContent content = null;
+        private readonly Lazy<Task<string>> body = null;
+
+        protected readonly IDictionary<string, string[]> messageHeaders = null;
+
+        public WebApiMessage(HttpContent content)
+        {
+            this.content = content;
+
+            this.body = new Lazy<Task<string>>(async () =>
+            {
+                if (this.content != null)
+                {
+                    await this.content.LoadIntoBufferAsync();
+                    return await this.content.ReadAsStringAsync();
+                }
+
+                return null;
+            });
+
+            this.messageHeaders = new Dictionary<string, string[]>();
+
+            if (this.content != null)
+                this.content.Headers.ToList()
+                    .ForEach(h => this.messageHeaders.Add(h.Key, h.Value.ToArray()));
+        }
+
+        public async Task<string> ReadBodyAsStringAsync()
+        {
+            return await this.body.Value;
+        }
+
+        public string ContentType
+        {
+            get
+            {
+                if (this.content != null)
+                {
+                    var contentType = this.content.Headers.ContentType;
+                    if (contentType != null)
+                        return contentType.MediaType;
+                }
+
+                return null;
+            }
+        }
+
+        public IDictionary<string, string[]> Headers
+        {
+            get
+            {
+                return this.messageHeaders;
+            }
+        }
+    }
+}

--- a/src/Hawk/WebApi/WebApiRequestMessage.cs
+++ b/src/Hawk/WebApi/WebApiRequestMessage.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+namespace Thinktecture.IdentityModel.Hawk.WebApi
+{
+    public class WebApiRequestMessage : WebApiMessage, IRequestMessage
+    {
+        private const string PARAMETER_KEY = "HK_Challenge";
+
+        private readonly HttpRequestMessage request = null;
+
+        public WebApiRequestMessage(HttpRequestMessage request) : base(request.Content)
+        {
+            this.request = request;
+
+            this.request.Headers.ToList()
+                .ForEach(h => this.messageHeaders.Add(h.Key, h.Value.ToArray()));
+        }
+
+        public string ChallengeParameter
+        {
+            get
+            {
+                if (this.request.Properties.ContainsKey(PARAMETER_KEY))
+                {
+                    return (string)this.request.Properties[PARAMETER_KEY];
+                }
+
+                return null;
+            }
+            set
+            {
+                this.request.Properties[PARAMETER_KEY] = value;
+            }
+        }
+
+        public string Host
+        {
+            get
+            {
+                return this.request.Headers.Host;
+            }
+        }
+
+		public AuthenticationHeaderValue Authorization
+        {
+            get
+            {
+                return this.request.Headers.Authorization;
+            }
+            set
+            {
+                this.request.Headers.Authorization = value;
+            }
+        }
+
+        public Uri Uri
+        {
+            get
+            {
+                return this.request.RequestUri;
+            }
+        }
+
+        public HttpMethod Method
+        {
+            get
+            {
+                return this.request.Method;
+            }
+        }
+
+        public string QueryString
+        {
+            set
+            {
+                UriBuilder builder = new UriBuilder(this.request.RequestUri);
+                builder.Query = value ?? String.Empty;
+
+                this.request.RequestUri = builder.Uri;
+            }
+        }
+
+        public string Scheme
+        {
+            get
+            {
+                return this.request.RequestUri.Scheme;
+            }
+        }
+    }
+}

--- a/src/Hawk/WebApi/WebApiResponseMessage.cs
+++ b/src/Hawk/WebApi/WebApiResponseMessage.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Thinktecture.IdentityModel.Hawk.Core.Helpers;
+using Thinktecture.IdentityModel.Hawk.Core.MessageContracts;
+
+namespace Thinktecture.IdentityModel.Hawk.WebApi
+{
+    public class WebApiResponseMessage : WebApiMessage, IResponseMessage
+    {
+        private readonly HttpResponseMessage response = null;
+
+        public WebApiResponseMessage(HttpResponseMessage response) : base(response.Content)
+        {
+            this.response = response;
+
+            this.response.Headers.ToList()
+                .ForEach(h => this.messageHeaders.Add(h.Key, h.Value.ToArray()));
+        }
+
+        public HttpStatusCode StatusCode
+        {
+            get
+            {
+                return this.response.StatusCode;
+            }
+        }
+
+        public AuthenticationHeaderValue WwwAuthenticate
+        {
+            get
+            {
+                var headers = this.response.Headers.WwwAuthenticate;
+
+                if (headers != null)
+                    return headers.FirstOrDefault(h => h.Scheme.ToLower() == HawkConstants.Scheme);
+
+                return null;
+            }
+        }
+
+        public void AddHeader(string name, string value)
+        {
+            this.response.Headers.Add(name, value);
+        }
+    }
+}

--- a/src/Hawk/project.json
+++ b/src/Hawk/project.json
@@ -1,0 +1,62 @@
+{
+  "version": "2.0.0-beta5",
+  "authors": [ "Dominick Baier", "Brock Allen" ],
+
+  "packOptions": {
+    "tags": [ "Hawk", "Security", "Identity", "IdentityServer" ],
+    "projectUrl": "https://github.com/IdentityModel/IdentityModelv2",
+    "licenseUrl": "https://github.com/IdentityModel/IdentityModelv2/blob/master/LICENSE",
+    "iconUrl": "https://identityserver.github.io/Documentation/assets/images/icons/IDmodel_icon128.png",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/identitymodel/identitymodelv2"
+    }
+  },
+
+  "dependencies": {
+      "Microsoft.AspNetCore.WebUtilities": "1.0.0",
+      "Microsoft.Extensions.Caching.Memory": "1.0.0",
+      "Newtonsoft.Json": "9.0.1"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "dependencies": {
+        "Microsoft.AspNetCore.Http.Abstractions": "1.0.0",
+        "Microsoft.AspNetCore.Http": "1.0.0",
+        "Microsoft.AspNetCore.Mvc.Core": "1.0.0",
+        "System.Diagnostics.Tracing": "4.1.0",
+        "System.Net.Http": "4.1.0",
+        "System.Security.Claims": "4.0.1",
+        "System.Security.Cryptography.Algorithms": "4.2.0"
+      }
+    },
+
+    "net452": {
+      "frameworkAssemblies": {
+        "System.Net.Http": "",
+        "System.Diagnostics.Tracing": ""
+      },
+      "dependencies": {
+        "Microsoft.AspNet.WebApi.Client": "5.2.3",
+        "Microsoft.AspNet.WebApi.Core": "5.2.3",
+        "Microsoft.Owin": "3.0.0",
+        "Microsoft.Owin.Security": "3.0.0",
+        "Owin": "1.0.0"
+      }
+    }
+  },
+   "configurations": {
+    "Debug": {
+      "buildOptions": {
+        "define": [ "DEBUG", "TRACE" ]
+      }
+    },
+    "Release": {
+      "buildOptions": {
+        "define": [ "RELEASE", "TRACE" ],
+        "optimize": true
+      }
+    }
+   } 
+}


### PR DESCRIPTION
Feel free to reject this PR, for now it is a courtesy. I needed the Hawk suppot from Identity Model to move forward with Brighter https://github.com/iancooper/Paramore

It builds, but does not offer all the functionality required for a working version, yet. I need a build to get tests to pass, to be able to then move forward with debugging this and adding some missing pipeline support.

If you are interested I can resubmit when we get it working

I also appreciate that this repository is experimental.
