### PR TITLE
Allow proper instatiation of UserInfoClient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ var token = response.AccessToken;
 Client library for the OpenID Connect user info endpoint
 
 ```csharp
-var userInfoClient = new UserInfoClient(doc.UserInfoEndpoint, token);
+var userInfoClient = new UserInfoClient(doc.UserInfoEndpoint);
 
-var response = await userInfoClient.GetAsync();
+var response = await userInfoClient.GetAsync(token);
 var claims = response.Claims;
 ```
 

--- a/src/IdentityModel/Client/UserInfoClient.cs
+++ b/src/IdentityModel/Client/UserInfoClient.cs
@@ -14,17 +14,14 @@ namespace IdentityModel.Client
     {
         private readonly HttpClient _client;
 
-        public UserInfoClient(string endpoint, string token)
-            : this(endpoint, token, new HttpClientHandler())
+        public UserInfoClient(string endpoint)
+            : this(endpoint, new HttpClientHandler())
         { }
 
-        public UserInfoClient(string endpoint, string token, HttpMessageHandler innerHttpMessageHandler)
+        public UserInfoClient(string endpoint, HttpMessageHandler innerHttpMessageHandler)
         {
             if (endpoint == null)
                 throw new ArgumentNullException("endpoint");
-
-            if (string.IsNullOrEmpty(token))
-                throw new ArgumentNullException("token");
 
             if (innerHttpMessageHandler == null)
                 throw new ArgumentNullException("innerHttpMessageHandler");
@@ -37,8 +34,6 @@ namespace IdentityModel.Client
             _client.DefaultRequestHeaders.Accept.Clear();
             _client.DefaultRequestHeaders.Accept.Add(
                 new MediaTypeWithQualityHeaderValue("application/json"));
-
-            _client.SetBearerToken(token);
         }
 
         public TimeSpan Timeout
@@ -49,9 +44,15 @@ namespace IdentityModel.Client
             }
         }
 
-        public async Task<UserInfoResponse> GetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<UserInfoResponse> GetAsync(string token, string tokenType = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = await _client.GetAsync("", cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(token))
+                throw new ArgumentNullException("token");
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "");
+            request.Headers.Authorization = new AuthenticationHeaderValue(tokenType ?? "Bearer", token);
+
+            var response = await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.OK)
             {


### PR DESCRIPTION
This patch allows reuse the UserInfoClient as shown on patterns & pratices guide for performance optimization.

There are a section on guide called improper instatiation that shows the correct usage of the HttpClient class (https://github.com/mspnp/performance-optimization/blob/master/ImproperInstantiation/docs/ImproperInstantiation.md).

With current implementation we can not share the UserInfoClient (and the internal HttpClient) because the token is passed on class constructor.

So I changed the class to receive the token (and an optional token type) on method GetAsync.

With this implementation we can share the UserInfoClient instance as recommended on p&p performance documentation.
