### PR TITLE
Adding ConfigureAwait() directive to await statement in TokenClient.RequestAsync()

### DIFF
--- a/src/IdentityModel/Client/TokenClient.cs
+++ b/src/IdentityModel/Client/TokenClient.cs
@@ -85,7 +85,7 @@ namespace IdentityModel.Client
 
             try
             {
-                response = await Client.SendAsync(request, cancellationToken);
+                response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
For issue #25.

Avoids deadlock when blocking on resulting task from within ASP.NET and other multi-synch context environments.

