### PR TITLE
Added UiLocales to EndSessionRequest.

### DIFF
--- a/src/IdentityModel/OidcConstants.cs
+++ b/src/IdentityModel/OidcConstants.cs
@@ -71,6 +71,7 @@ namespace IdentityModel
             public const string State = "state";
             public const string Sid = "sid";
             public const string Issuer = "iss";
+            public const string UiLocales = "ui_locales";
         }
 
         public static class TokenRequest
@@ -278,7 +279,7 @@ namespace IdentityModel
             public const string ConfirmationByTelephone = "tel";
             public const string UserPresenceTest = "user";
             public const string VoiceBiometric = "vbm";
-            public const string WindowsIntegratedAuthentication = "wia";           
+            public const string WindowsIntegratedAuthentication = "wia";
         }
 
         public static class Algorithms


### PR DESCRIPTION
Added UiLocales to EndSessionRequest.
The LogoutUrl in the UserInteractionOptions to include ui_locales if provided while calling the EndSessionEndpoint of IdentityServer4.
This is With reference to comment provided in the issue https://github.com/IdentityServer/IdentityServer4/issues/1305
Need to modify IdentityServer4 to include ui_locales if available in the EndSessionRequest while redirecting to LogoutUrl.