### PR TITLE
Azure AD B2C Policy support

### DIFF
--- a/src/IdentityModel/Client/AuthorizeRequest.cs
+++ b/src/IdentityModel/Client/AuthorizeRequest.cs
@@ -42,13 +42,20 @@ namespace IdentityModel.Client
         {
             var qs = string.Join("&", values.Select(kvp => string.Format("{0}={1}", WebUtility.UrlEncode(kvp.Key), WebUtility.UrlEncode(kvp.Value))).ToArray());
 
+            var seperator = '?';
+
+            if (!String.IsNullOrEmpty(_authorizeEndpoint.Query))
+            {
+                seperator = '&';
+            }
+
             if (_authorizeEndpoint.IsAbsoluteUri)
             {
-                return string.Format("{0}?{1}", _authorizeEndpoint.AbsoluteUri, qs);
+                return string.Format("{0}{1}{2}", _authorizeEndpoint.AbsoluteUri,seperator, qs);
             }
             else
             {
-                return string.Format("{0}?{1}", _authorizeEndpoint.OriginalString, qs);
+                return string.Format("{0}{1}{2}", _authorizeEndpoint.OriginalString, seperator, qs);
             }
         }
     }

--- a/src/IdentityModel/Client/DiscoveryClient.cs
+++ b/src/IdentityModel/Client/DiscoveryClient.cs
@@ -56,7 +56,7 @@ namespace IdentityModel.Client
 
             var url = input.RemoveTrailingSlash();
 
-            if (url.EndsWith(OidcConstants.Discovery.DiscoveryEndpoint, StringComparison.OrdinalIgnoreCase))
+            if (url.ToLowerInvariant().Contains(OidcConstants.Discovery.DiscoveryEndpoint))
             {
                 discoveryEndpoint = url;
                 authority = url.Substring(0, url.Length - OidcConstants.Discovery.DiscoveryEndpoint.Length - 1);


### PR DESCRIPTION
Modified the DiscoveryClient to accept well formatted metadata addresses that contain query string parameters. Modified the AuthorizeRequest URL builder to not blindly add a querystring as one may already exist. Both modifications specifically target supporting [Azure AD B2C Policies](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-policies) with this library. 