### PR TITLE
Enabled DiscoveryClient to obey DiscoveryPolicy.Authority

### DIFF
--- a/src/IdentityModel/Client/DiscoveryClient.cs
+++ b/src/IdentityModel/Client/DiscoveryClient.cs
@@ -120,7 +120,7 @@ namespace IdentityModel.Client
             var handler = innerHandler ?? new HttpClientHandler();
 
             (Authority, Url) = ParseUrl(authority);
-            
+
             _client = new HttpClient(handler);
         }
 
@@ -131,7 +131,11 @@ namespace IdentityModel.Client
         /// <returns></returns>
         public async Task<DiscoveryResponse> GetAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            Policy.Authority = Authority;
+            if (string.IsNullOrEmpty(Policy.Authority))
+            {
+                Policy.Authority = Authority;
+            }
+
             string jwkUrl = "";
 
             if (!DiscoveryUrlHelper.IsSecureScheme(new Uri(Url), Policy))
@@ -154,7 +158,7 @@ namespace IdentityModel.Client
                     return disco;
                 }
 
-                
+
                 try
                 {
                     jwkUrl = disco.JwksUri;

--- a/src/IdentityModel/Client/DiscoveryPolicy.cs
+++ b/src/IdentityModel/Client/DiscoveryPolicy.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace IdentityModel.Client
@@ -14,6 +15,11 @@ namespace IdentityModel.Client
         /// Gets or sets the Authority on which the policy checks will be based on
         /// </summary>
         public string Authority { get; set; }
+
+        /// <summary>
+        /// Method of comparison for issuer and authority names. Defaults to <see cref="StringComparison.Ordinal" />
+        /// </summary>
+        public StringComparison AuthorityNameComparison { get; set; } = StringComparison.Ordinal;
 
         /// <summary>
         /// Specifies if HTTPS is enforced on all endpoints. Defaults to true.

--- a/src/IdentityModel/Client/DiscoveryResponse.cs
+++ b/src/IdentityModel/Client/DiscoveryResponse.cs
@@ -181,7 +181,7 @@ namespace IdentityModel.Client
             {
                 if (string.IsNullOrWhiteSpace(Issuer)) return "Issuer name is missing";
 
-                var isValid = ValidateIssuerName(Issuer.RemoveTrailingSlash(), policy.Authority.RemoveTrailingSlash());
+                var isValid = ValidateIssuerName(Issuer.RemoveTrailingSlash(), policy.Authority.RemoveTrailingSlash(), policy.AuthorityNameComparison);
                 if (!isValid) return "Issuer name does not match authority: " + Issuer;
             }
 
@@ -199,7 +199,19 @@ namespace IdentityModel.Client
         /// <returns></returns>
         public bool ValidateIssuerName(string issuer, string authority)
         {
-            return string.Equals(issuer, authority, StringComparison.Ordinal);
+            return ValidateIssuerName(issuer, authority, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Checks if the issuer matches the authority.
+        /// </summary>
+        /// <param name="issuer">The issuer.</param>
+        /// <param name="authority">The authority.</param>
+        /// <param name="nameComparison">The comparison mechanism that should be used when performing the match.</param>
+        /// <returns></returns>
+        public bool ValidateIssuerName(string issuer, string authority, StringComparison nameComparison)
+        {
+            return string.Equals(issuer, authority, nameComparison);
         }
 
         /// <summary>
@@ -265,7 +277,7 @@ namespace IdentityModel.Client
                         isAllowed = false;
                         foreach (var authority in allowedAuthorities)
                         {
-                            if (endpoint.StartsWith(authority, StringComparison.Ordinal))
+                            if (endpoint.StartsWith(authority, policy.AuthorityNameComparison))
                             {
                                 isAllowed = true;
                             }

--- a/test/UnitTests/DiscoveryClientTests.cs
+++ b/test/UnitTests/DiscoveryClientTests.cs
@@ -79,6 +79,25 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
+        public async Task Policy_authority_does_not_get_overwritten()
+        {
+            var policy = new DiscoveryPolicy
+            {
+                Authority = "https://server:123"
+            };
+
+            var client = new DiscoveryClient(_endpoint, _successHandler)
+            {
+                Policy = policy
+            };
+
+            var disco = await client.GetAsync();
+
+            disco.IsError.Should().BeTrue();
+            policy.Authority.Should().Be("https://server:123");
+        }
+
+        [Fact]
         public async Task Exception_should_be_handled_correctly()
         {
             var handler = new NetworkHandler(new Exception("error"));

--- a/test/UnitTests/DiscoveryPolicyTests.cs
+++ b/test/UnitTests/DiscoveryPolicyTests.cs
@@ -128,7 +128,7 @@ namespace IdentityModel.UnitTests
             disco.IsError.Should().BeFalse();
         }
 
-        
+
         [Fact]
         public async Task invalid_issuer_name_must_return_policy_error()
         {
@@ -181,6 +181,20 @@ namespace IdentityModel.UnitTests
             var client = new DiscoveryClient("https://authority", handler)
             {
                 Policy = {ValidateIssuerName = true}
+            };
+
+            var disco = await client.GetAsync();
+
+            disco.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task authority_comparison_may_be_case_insensitive()
+        {
+            var handler = GetHandler("https://authority/tenantid");
+            var client = new DiscoveryClient("https://authority/TENANTID", handler)
+            {
+                Policy = { ValidateIssuerName = true, AuthorityNameComparison=StringComparison.OrdinalIgnoreCase }
             };
 
             var disco = await client.GetAsync();


### PR DESCRIPTION
Addresses #58.

- Ability to override the string comparison for issuer and authority values. Defaults to `StringComparison.Ordinal`.
- `DiscoveryClient` only updates the policy `Authority` if none is specified; otherwise the client obeys what is in the policy already.