### PR TITLE
RefreshTokenHandler: Disposal of first unauthorized response

### DIFF
--- a/src/IdentityModel/Client/RefreshTokenHandler.cs
+++ b/src/IdentityModel/Client/RefreshTokenHandler.cs
@@ -137,6 +137,8 @@ namespace IdentityModel.Client
                 return response;
             }
 
+            response.Dispose(); // This 401 response will not be used for anything so is disposed to unblock the socket.
+
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }

--- a/test/UnitTests/RefreshTokenHandlerTests.cs
+++ b/test/UnitTests/RefreshTokenHandlerTests.cs
@@ -1,0 +1,82 @@
+﻿using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using Xunit;
+
+namespace IdentityModel.UnitTests
+{
+    public class HttpResponseMessageMock : HttpResponseMessage
+    {
+        public HttpResponseMessageMock(HttpStatusCode code) : base(code)
+        {
+        }
+
+        public bool Disposed { get; set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    public class StubHttpResponsesHandler : DelegatingHandler
+    {
+        private bool _first401ResponseSent;
+
+        public StubHttpResponsesHandler()
+        {
+            FirstAttempt401Response = new HttpResponseMessageMock(HttpStatusCode.Unauthorized);
+        }
+
+        public HttpResponseMessageMock FirstAttempt401Response { get; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (false == _first401ResponseSent)
+            {
+                _first401ResponseSent = true;
+                return Task.FromResult(FirstAttempt401Response as HttpResponseMessage);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    public class RefreshTokenHandlerTests
+    {
+        [Fact]
+        public async Task The_401_response_that_causes_token_refresh_and_retry_should_be_disposed_to_unblock_socket()
+        {
+            var document = File.ReadAllText(FileName.Create("success_token_response.json"));
+            var handler = new NetworkHandler(document, HttpStatusCode.OK);
+
+            var tokenClient = new TokenClient(
+                "http://server/token",
+                "client",
+                handler);
+
+            var tokenResponse = await tokenClient.RequestClientCredentialsAsync();
+
+            var indirectOutputOfHttpResponses = new StubHttpResponsesHandler();
+            var refreshHandler = new RefreshTokenHandler(
+                tokenClient,
+                tokenResponse.RefreshToken,
+                tokenResponse.AccessToken,
+                indirectOutputOfHttpResponses);
+
+            var apiClient = new HttpClient(refreshHandler);
+
+            await apiClient.GetStringAsync("http://someapi/somecall");
+
+            indirectOutputOfHttpResponses.FirstAttempt401Response
+                .Disposed
+                .Should()
+                .BeTrue("Unauthorized response should be disposed to avoid socket blocking");
+        }
+    }
+}


### PR DESCRIPTION
RefreshTokenHandler can receive 401 on first attempt to make a call. This results in token refresh and subsequent retry. The 401 response  needs to be disposed though to prevent socket blocking and potential timeouts.