### PR TITLE
Add AccessTokenHandler - a helper to renew access tokens in for client credentials flows

### DIFF
--- a/src/IdentityModel/Client/AccessTokenHandler.cs
+++ b/src/IdentityModel/Client/AccessTokenHandler.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using IdentityModel.Internal;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.Client
+{
+    /// <summary>
+    /// HTTP message handler that encapsulates access token handling and renew
+    /// </summary>
+    public class AccessTokenHandler : DelegatingHandler
+    {
+        private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+        private readonly TokenClient _tokenClient;
+        private readonly string _scope;
+
+        private string _accessToken;
+        private bool _disposed;
+
+        /// <summary>
+        /// Gets or sets the timeout
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
+        
+        /// <summary>
+        /// Gets the current access token
+        /// </summary>
+        public string AccessToken
+        {
+            get
+            {
+                if (_lock.Wait(Timeout))
+                {
+                    try
+                    {
+                        return _accessToken;
+                    }
+                    finally
+                    {
+                        _lock.Release();
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Occurs when the tokens were renewed successfully
+        /// </summary>
+        public event EventHandler<TokenRenewedEventArgs> TokenRenewed = delegate { };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenHandler"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="accessToken">The access token.</param>
+        /// <param name="innerHandler">The inner handler.</param>
+        public AccessTokenHandler(string tokenEndpoint, string clientId, string clientSecret, string scope, string accessToken = null, HttpMessageHandler innerHandler = null)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), scope, accessToken, innerHandler)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenHandler"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="accessToken">The access token.</param>
+        /// <param name="innerHandler">The inner handler.</param>
+        public AccessTokenHandler(TokenClient client, string scope, string accessToken = null, HttpMessageHandler innerHandler = null)
+        {
+            _tokenClient = client;
+            _scope = scope;
+            _accessToken = accessToken;
+
+            InnerHandler = innerHandler ?? new HttpClientHandler();
+        }
+
+        /// <summary>
+        /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
+        /// </summary>
+        /// <param name="request">The HTTP request message to send to the server.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
+        /// <returns>
+        /// Returns <see cref="T:System.Threading.Tasks.Task`1" />. The task object representing the asynchronous operation.
+        /// </returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var accessToken = await GetAccessTokenAsync(cancellationToken);
+            if (accessToken.IsMissing())
+            {
+                if (await RenewTokensAsync(cancellationToken) == false)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                }
+            }
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                return response;
+            }
+
+            if (await RenewTokensAsync(cancellationToken) == false)
+            {
+                return response;
+            }
+
+            response.Dispose(); // This 401 response will not be used for anything so is disposed to unblock the socket.
+
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the <see cref="T:System.Net.Http.DelegatingHandler" />, and optionally disposes of the managed resources.
+        /// </summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to releases only unmanaged resources.</param>
+        protected override void Dispose(bool disposing)
+        {
+          if (disposing && !_disposed) {
+              _disposed = true;
+              _lock.Dispose();
+          }
+
+          base.Dispose(disposing);
+        }
+
+        private async Task<bool> RenewTokensAsync(CancellationToken cancellationToken)
+        {
+            if (await _lock.WaitAsync(Timeout, cancellationToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    var response = await _tokenClient.RequestClientCredentialsAsync(_scope, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    if (!response.IsError)
+                    {
+                        _accessToken = response.AccessToken;
+
+#pragma warning disable 4014
+                        Task.Run(() =>
+                        {
+                            foreach (EventHandler<TokenRenewedEventArgs> del in TokenRenewed.GetInvocationList())
+                            {
+                                try
+                                {
+                                    del(this, new TokenRenewedEventArgs(response.AccessToken, response.ExpiresIn));
+                                }
+                                catch { }
+                            }
+                        }).ConfigureAwait(false);
+#pragma warning restore 4014
+
+                        return true;
+                    }
+                }
+                finally
+                {
+                    _lock.Release();
+                }
+            }
+
+            return false;
+        }
+
+        private async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
+        {
+            if (await _lock.WaitAsync(Timeout, cancellationToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    return _accessToken;
+                }
+                finally
+                {
+                    _lock.Release();
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/IdentityModel/Client/AccessTokenHandler.cs
+++ b/src/IdentityModel/Client/AccessTokenHandler.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace IdentityModel.Client
 {
     /// <summary>
-    /// HTTP message handler that encapsulates access token handling and renew
+    /// HTTP message handler that encapsulates access token handling and renewment
     /// </summary>
     public class AccessTokenHandler : DelegatingHandler
     {
@@ -57,7 +57,7 @@ namespace IdentityModel.Client
         public event EventHandler<TokenRenewedEventArgs> TokenRenewed = delegate { };
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RefreshTokenHandler"/> class.
+        /// Initializes a new instance of the <see cref="AccessTokenHandler"/> class.
         /// </summary>
         /// <param name="tokenEndpoint">The token endpoint.</param>
         /// <param name="clientId">The client identifier.</param>
@@ -70,7 +70,7 @@ namespace IdentityModel.Client
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RefreshTokenHandler"/> class.
+        /// Initializes a new instance of the <see cref="AccessTokenHandler"/> class.
         /// </summary>
         /// <param name="client">The client.</param>
         /// <param name="scope">The scope.</param>

--- a/src/IdentityModel/Client/AccessTokenHandler.cs
+++ b/src/IdentityModel/Client/AccessTokenHandler.cs
@@ -63,10 +63,9 @@ namespace IdentityModel.Client
         /// <param name="clientId">The client identifier.</param>
         /// <param name="clientSecret">The client secret.</param>
         /// <param name="scope">The scope.</param>
-        /// <param name="accessToken">The access token.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public AccessTokenHandler(string tokenEndpoint, string clientId, string clientSecret, string scope, string accessToken = null, HttpMessageHandler innerHandler = null)
-            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), scope, accessToken, innerHandler)
+        public AccessTokenHandler(string tokenEndpoint, string clientId, string clientSecret, string scope, HttpMessageHandler innerHandler = null)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), scope, innerHandler)
         { }
 
         /// <summary>
@@ -74,13 +73,11 @@ namespace IdentityModel.Client
         /// </summary>
         /// <param name="client">The client.</param>
         /// <param name="scope">The scope.</param>
-        /// <param name="accessToken">The access token.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public AccessTokenHandler(TokenClient client, string scope, string accessToken = null, HttpMessageHandler innerHandler = null)
+        public AccessTokenHandler(TokenClient client, string scope, HttpMessageHandler innerHandler = null)
         {
             _tokenClient = client;
             _scope = scope;
-            _accessToken = accessToken;
 
             InnerHandler = innerHandler ?? new HttpClientHandler();
         }

--- a/src/IdentityModel/Client/TokenRenewedEventArgs.cs
+++ b/src/IdentityModel/Client/TokenRenewedEventArgs.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace IdentityModel.Client
+{
+    /// <summary>
+    /// Event argument with the refreshed token
+    /// </summary>
+    public class TokenRenewedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokenRenewedEventArgs" /> class.
+        /// </summary>
+        /// <param name="accessToken">The access token.</param>
+        /// <param name="expiresIn">The expires in.</param>
+        public TokenRenewedEventArgs(string accessToken, int expiresIn)
+        {
+            AccessToken = accessToken;
+            ExpiresIn = expiresIn;
+        }
+
+        /// <summary>
+        /// Gets the access token.
+        /// </summary>
+        /// <value>
+        /// The access token.
+        /// </value>
+        public string AccessToken { get; }
+
+        /// <summary>
+        /// Gets or sets the expires in.
+        /// </summary>
+        /// <value>
+        /// The expires in.
+        /// </value>
+        public int ExpiresIn { get; }
+    }
+}

--- a/test/UnitTests/AccessTokenHandlerTests.cs
+++ b/test/UnitTests/AccessTokenHandlerTests.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using Xunit;
+
+namespace IdentityModel.UnitTests
+{
+    public class AccessTokenHandlerTests
+    {
+        [Fact]
+        public async Task The_401_response_that_causes_token_refresh_and_retry_should_be_disposed_to_unblock_socket()
+        {
+            var document = File.ReadAllText(FileName.Create("success_token_response.json"));
+            var handler = new NetworkHandler(document, HttpStatusCode.OK);
+
+            using (var tokenClient = new TokenClient(
+                "http://server/token",
+                "client",
+                handler))
+            {
+                var indirectOutputOfHttpResponses = new StubHttpResponsesHandler();
+                var accessTokenHandler = new AccessTokenHandler(
+                    tokenClient,
+                    "scope",
+                    innerHandler: indirectOutputOfHttpResponses);
+
+                var apiClient = new HttpClient(accessTokenHandler);
+
+                await apiClient.GetStringAsync("http://someapi/somecall");
+
+                indirectOutputOfHttpResponses.FirstAttempt401Response
+                    .Disposed
+                    .Should()
+                    .BeTrue("Unauthorized response should be disposed to avoid socket blocking");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Similar to RefreshTokenHandler, this will renew an access token in the event that it expires (and client is not authorized). Uses the term "renew" so as not to confuse with the term "refresh".