### PR TITLE
Refresh token should be retained if token response contains only access token

### DIFF
--- a/src/IdentityModel/Client/RefreshTokenHandler.cs
+++ b/src/IdentityModel/Client/RefreshTokenHandler.cs
@@ -177,7 +177,10 @@ namespace IdentityModel.Client
                     if (!response.IsError)
                     {
                         _accessToken = response.AccessToken;
-                        _refreshToken = response.RefreshToken;
+                        if (!response.RefreshToken.IsMissing())
+                        {
+                            _refreshToken = response.RefreshToken;
+                        }
 
 #pragma warning disable 4014
                         Task.Run(() =>

--- a/test/UnitTests/documents/success_access_token_response.json
+++ b/test/UnitTests/documents/success_access_token_response.json
@@ -1,0 +1,6 @@
+﻿{
+  "access_token": "access_token",
+  "expires_in": 3600,
+  "token_type": "Bearer",
+  "custom":  "custom"
+}


### PR DESCRIPTION
Fix for #91