### PR TITLE
removed URL encoding from the Authorisation Header Generation

### DIFF
--- a/src/IdentityModel/Client/BasicAuthenticationOAuthHeaderValue.cs
+++ b/src/IdentityModel/Client/BasicAuthenticationOAuthHeaderValue.cs
@@ -27,19 +27,11 @@ namespace System.Net.Http
             if (password == null) password = "";
 
             Encoding encoding = Encoding.UTF8;
-            string credential = $"{UrlEncode(userName)}:{UrlEncode(password)}";
+            string credential = $"{userName}:{password}";
 
-            return Convert.ToBase64String(encoding.GetBytes(credential));
-        }
+            var base64Creds = Convert.ToBase64String(encoding.GetBytes(credential));
 
-        private static string UrlEncode(string value)
-        {
-            if (String.IsNullOrEmpty(value))
-            {
-                return String.Empty;
-            }
-            
-            return Uri.EscapeDataString(value).Replace("%20", "+");
+            return base64Creds;
         }
     }
 }

--- a/test/UnitTests/BasicAuthenticationEncodingTests.cs
+++ b/test/UnitTests/BasicAuthenticationEncodingTests.cs
@@ -19,6 +19,7 @@ namespace IdentityModel.UnitTests
         [InlineData("firstname:lastname", "bar:bar2")]
         [InlineData("sören:müller", "bar:bar2")]
         [InlineData(":/&%%(/(&/) %&%&/%/&", ")(/)(/&  /%/&%$&$$&")]
+        [InlineData("R413926C", "YDN4ZPE9oRszY+0Ks7J=kdoiiMgMDT4ppWw4ZNYLbag=")]
         public void oauth_values_should_decode_correctly(string id, string secret)
         {
             var header = new BasicAuthenticationOAuthHeaderValue(id, secret);
@@ -33,8 +34,8 @@ namespace IdentityModel.UnitTests
             var unbased = Unbase64(value);
             var items = unbased.Split(':');
 
-            id = Uri.UnescapeDataString(items[0].Replace("+", "%20"));
-            secret = Uri.UnescapeDataString(items[1].Replace("+", "%20"));
+            id = items[0];
+            secret = items[1];
         }
 
         private string Unbase64(string value)


### PR DESCRIPTION
The clientID and secret were being individually URL Encoded before being Base64 encoded for the Authorisation header.

There is no requirement for these properties or any aspect of the Authorisation header to be URL Encoded.  

See RFC2617:
https://tools.ietf.org/html/rfc2617#section-2

As such, Identity Server was not performing URL Decoding on the Auth header and this resulted in the following example failing:
ClientID: CL5678
Secret: IzPUVgzkGm=I7T/rOBoWVzUxX6+Ndq/dMwrsokLLF7+kg=


