### PR TITLE
AccessToken and RefreshToken Handlers - do not create a default inner handler. 

### DIFF
--- a/src/IdentityModel/Client/AccessTokenDelegatingHandler.cs
+++ b/src/IdentityModel/Client/AccessTokenDelegatingHandler.cs
@@ -12,12 +12,9 @@ using System.Threading.Tasks;
 namespace IdentityModel.Client
 {
     /// <summary>
-    /// HTTP message handler that encapsulates access token handling and renewment
+    /// HTTP message delegating handler that encapsulates access token handling and renewment
     /// </summary>
-    [Obsolete("Use AccesTokenDelegatingHandler (that does not create a default " +
-              "inner handler) instead. See " +
-              "https://github.com/IdentityModel/IdentityModel2/pull/110", false)]
-    public class AccessTokenHandler : DelegatingHandler
+    public class AccessTokenDelegatingHandler : DelegatingHandler
     {
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
         private readonly TokenClient _tokenClient;
@@ -60,29 +57,28 @@ namespace IdentityModel.Client
         public event EventHandler<TokenRenewedEventArgs> TokenRenewed = delegate { };
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AccessTokenHandler"/> class.
+        /// Initializes a new instance of the <see cref="AccessTokenDelegatingHandler"/> class.
         /// </summary>
         /// <param name="tokenEndpoint">The token endpoint.</param>
         /// <param name="clientId">The client identifier.</param>
         /// <param name="clientSecret">The client secret.</param>
         /// <param name="scope">The scope.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public AccessTokenHandler(string tokenEndpoint, string clientId, string clientSecret, string scope, HttpMessageHandler innerHandler = null)
+        public AccessTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string scope, HttpMessageHandler innerHandler = null)
             : this(new TokenClient(tokenEndpoint, clientId, clientSecret, innerHandler), scope, innerHandler)
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AccessTokenHandler"/> class.
+        /// Initializes a new instance of the <see cref="AccessTokenDelegatingHandler"/> class.
         /// </summary>
         /// <param name="client">The client.</param>
         /// <param name="scope">The scope.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public AccessTokenHandler(TokenClient client, string scope, HttpMessageHandler innerHandler = null)
+        public AccessTokenDelegatingHandler(TokenClient client, string scope, HttpMessageHandler innerHandler = null)
+            : base(innerHandler)
         {
             _tokenClient = client;
             _scope = scope;
-
-            InnerHandler = innerHandler ?? new HttpClientHandler();
         }
 
         /// <summary>

--- a/src/IdentityModel/Client/AccessTokenHandler.cs
+++ b/src/IdentityModel/Client/AccessTokenHandler.cs
@@ -79,7 +79,7 @@ namespace IdentityModel.Client
             _tokenClient = client;
             _scope = scope;
 
-            InnerHandler = innerHandler ?? new HttpClientHandler();
+            InnerHandler = innerHandler;
         }
 
         /// <summary>

--- a/src/IdentityModel/Client/AccessTokenHandler.cs
+++ b/src/IdentityModel/Client/AccessTokenHandler.cs
@@ -79,7 +79,7 @@ namespace IdentityModel.Client
             _tokenClient = client;
             _scope = scope;
 
-            InnerHandler = innerHandler;
+            InnerHandler = innerHandler ?? new HttpClientHandler();
         }
 
         /// <summary>

--- a/src/IdentityModel/Client/RefreshTokenHandler.cs
+++ b/src/IdentityModel/Client/RefreshTokenHandler.cs
@@ -105,7 +105,7 @@ namespace IdentityModel.Client
             _refreshToken = refreshToken;
             _accessToken = accessToken;
 
-            InnerHandler = innerHandler ?? new HttpClientHandler();
+            InnerHandler = innerHandler;
         }
 
         /// <summary>

--- a/src/IdentityModel/Client/RefreshTokenHandler.cs
+++ b/src/IdentityModel/Client/RefreshTokenHandler.cs
@@ -105,7 +105,7 @@ namespace IdentityModel.Client
             _refreshToken = refreshToken;
             _accessToken = accessToken;
 
-            InnerHandler = innerHandler;
+            InnerHandler = innerHandler ?? new HttpClientHandler();
         }
 
         /// <summary>

--- a/src/IdentityModel/Client/RefreshTokenHandler.cs
+++ b/src/IdentityModel/Client/RefreshTokenHandler.cs
@@ -14,11 +14,13 @@ namespace IdentityModel.Client
     /// <summary>
     /// HTTP message handler that encapsulates token handling and refresh
     /// </summary>
+    [Obsolete("Use AccesTokenDelegatingHandler (that does not create a default " +
+              "inner handler) instead. See " +
+              "https://github.com/IdentityModel/IdentityModel2/pull/110", false)]
     public class RefreshTokenHandler : DelegatingHandler
     {
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
         private readonly TokenClient _tokenClient;
-
         private string _accessToken;
         private string _refreshToken;
         private bool _disposed;

--- a/test/UnitTests/AccessTokenDelegatingHandlerTests.cs
+++ b/test/UnitTests/AccessTokenDelegatingHandlerTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace IdentityModel.UnitTests
 {
-    public class AccessTokenHandlerTests
+    public class AccessTokenDelegatingHandlerTests
     {
         [Fact]
         public async Task The_401_response_that_causes_token_refresh_and_retry_should_be_disposed_to_unblock_socket()
@@ -22,7 +22,7 @@ namespace IdentityModel.UnitTests
                 handler))
             {
                 var indirectOutputOfHttpResponses = new StubHttpResponsesHandler();
-                var accessTokenHandler = new AccessTokenHandler(
+                var accessTokenHandler = new AccessTokenDelegatingHandler(
                     tokenClient,
                     "scope",
                     innerHandler: indirectOutputOfHttpResponses);

--- a/test/UnitTests/RefreshTokenDelegatingHandlerTests.cs
+++ b/test/UnitTests/RefreshTokenDelegatingHandlerTests.cs
@@ -47,7 +47,7 @@ namespace IdentityModel.UnitTests
         }
     }
 
-    public class RefreshTokenHandlerTests
+    public class RefreshTokenDelegatingHandlerTests
     {
         [Fact]
         public async Task The_401_response_that_causes_token_refresh_and_retry_should_be_disposed_to_unblock_socket()
@@ -63,7 +63,7 @@ namespace IdentityModel.UnitTests
             var tokenResponse = await tokenClient.RequestClientCredentialsAsync();
 
             var indirectOutputOfHttpResponses = new StubHttpResponsesHandler();
-            var refreshHandler = new RefreshTokenHandler(
+            var refreshHandler = new RefreshTokenDelegatingHandler(
                 tokenClient,
                 tokenResponse.RefreshToken,
                 tokenResponse.AccessToken,
@@ -91,7 +91,7 @@ namespace IdentityModel.UnitTests
                 handler);
 
             var indirectOutputOfHttpResponses = new StubHttpResponsesHandler();
-            var refreshHandler = new RefreshTokenHandler(
+            var refreshHandler = new RefreshTokenDelegatingHandler(
                 tokenClient,
                 "refresh_token",
                 "access_token",


### PR DESCRIPTION
Instead rely on it being set from the outside. Delegating handler already ensures that a value is set on first usage (and [prevents it from being changed after](https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs#L31)).

Fixes #109 