### PR TITLE
Adding net47 target.

### DIFF
--- a/src/IdentityModel/IdentityModel.csproj
+++ b/src/IdentityModel/IdentityModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netstandard1.4;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net461;net47;netstandard1.4;netstandard2.0</TargetFrameworks>
     <VersionPrefix>3.6.1</VersionPrefix>
     <!--<VersionSuffix>preview1</VersionSuffix>-->
     <Authors>Dominick Baier;Brock Allen</Authors>
@@ -34,5 +34,8 @@
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
   </ItemGroup>
 </Project>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net461;net47;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>UnitTests</AssemblyName>
     <PackageId>UnitTests</PackageId>
   </PropertyGroup>
@@ -38,6 +38,13 @@
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />


### PR DESCRIPTION
These changes add net47 as a target build, resolving issues with System.Net.Http in cases where you don't have a viable binding redirect option (such as creating a powershell cmdlet).