### PR TITLE
Fix AccessTokenDelegatingHandler ctor to prevent ANE from DelegatingHandler

### DIFF
--- a/src/IdentityModel/Client/AccessTokenDelegatingHandler.cs
+++ b/src/IdentityModel/Client/AccessTokenDelegatingHandler.cs
@@ -63,8 +63,19 @@ namespace IdentityModel.Client
         /// <param name="clientId">The client identifier.</param>
         /// <param name="clientSecret">The client secret.</param>
         /// <param name="scope">The scope.</param>
+        public AccessTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string scope)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), scope)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccessTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="scope">The scope.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public AccessTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string scope, HttpMessageHandler innerHandler = null)
+        public AccessTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string scope, HttpMessageHandler innerHandler)
             : this(new TokenClient(tokenEndpoint, clientId, clientSecret, innerHandler), scope, innerHandler)
         { }
 
@@ -73,8 +84,19 @@ namespace IdentityModel.Client
         /// </summary>
         /// <param name="client">The client.</param>
         /// <param name="scope">The scope.</param>
+        public AccessTokenDelegatingHandler(TokenClient client, string scope)
+        {
+            _tokenClient = client;
+            _scope = scope;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccessTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="scope">The scope.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public AccessTokenDelegatingHandler(TokenClient client, string scope, HttpMessageHandler innerHandler = null)
+        public AccessTokenDelegatingHandler(TokenClient client, string scope, HttpMessageHandler innerHandler)
             : base(innerHandler)
         {
             _tokenClient = client;

--- a/src/IdentityModel/Client/RefreshTokenDelegatingHandler.cs
+++ b/src/IdentityModel/Client/RefreshTokenDelegatingHandler.cs
@@ -86,11 +86,83 @@ namespace IdentityModel.Client
         /// <param name="clientId">The client identifier.</param>
         /// <param name="clientSecret">The client secret.</param>
         /// <param name="refreshToken">The refresh token.</param>
+        public RefreshTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string refreshToken)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), refreshToken)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="refreshToken">The refresh token.</param>
+        /// <param name="accessToken">The access token.</param>
+        public RefreshTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string refreshToken, string accessToken)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), refreshToken, accessToken)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="refreshToken">The refresh token.</param>
+        /// <param name="innerHandler">The inner handler.</param>
+        public RefreshTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string refreshToken, HttpMessageHandler innerHandler)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), refreshToken, innerHandler)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="refreshToken">The refresh token.</param>
         /// <param name="accessToken">The access token.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public RefreshTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string refreshToken, string accessToken = null, HttpMessageHandler innerHandler = null)
+        public RefreshTokenDelegatingHandler(string tokenEndpoint, string clientId, string clientSecret, string refreshToken, string accessToken, HttpMessageHandler innerHandler)
             : this(new TokenClient(tokenEndpoint, clientId, clientSecret), refreshToken, accessToken, innerHandler)
-        { }
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="refreshToken">The refresh token.</param>
+        public RefreshTokenDelegatingHandler(TokenClient client, string refreshToken)
+        {
+            _tokenClient = client;
+            _refreshToken = refreshToken;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="refreshToken">The refresh token.</param>
+        /// <param name="accessToken">The access token.</param>
+        public RefreshTokenDelegatingHandler(TokenClient client, string refreshToken, string accessToken)
+        {
+            _tokenClient = client;
+            _refreshToken = refreshToken;
+            _accessToken = accessToken;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="refreshToken">The refresh token.</param>
+        /// <param name="innerHandler">The inner handler.</param>
+        public RefreshTokenDelegatingHandler(TokenClient client, string refreshToken, HttpMessageHandler innerHandler)
+            :base(innerHandler)
+        {
+            _tokenClient = client;
+            _refreshToken = refreshToken;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
@@ -99,8 +171,8 @@ namespace IdentityModel.Client
         /// <param name="refreshToken">The refresh token.</param>
         /// <param name="accessToken">The access token.</param>
         /// <param name="innerHandler">The inner handler.</param>
-        public RefreshTokenDelegatingHandler(TokenClient client, string refreshToken, string accessToken = null, HttpMessageHandler innerHandler = null)
-            :base(innerHandler)
+        public RefreshTokenDelegatingHandler(TokenClient client, string refreshToken, string accessToken, HttpMessageHandler innerHandler)
+            : base(innerHandler)
         {
             _tokenClient = client;
             _refreshToken = refreshToken;

--- a/test/UnitTests/AccessTokenDelegatingHandlerTests.cs
+++ b/test/UnitTests/AccessTokenDelegatingHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -36,6 +37,23 @@ namespace IdentityModel.UnitTests
                     .Should()
                     .BeTrue("Unauthorized response should be disposed to avoid socket blocking");
             }
+        }
+
+        [Fact]
+        public void Creating_with_token_client_should_not_throw()
+        {
+            var tokenClient = new TokenClient("http://server/token", "client");
+            Action act = () => new AccessTokenDelegatingHandler(tokenClient, "scope");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Creating_should_not_throw()
+        {
+            Action act = () => new AccessTokenDelegatingHandler("http://server/token", "client", "secret", "scope");
+
+            act.Should().NotThrow();
         }
     }
 }

--- a/test/UnitTests/RefreshTokenDelegatingHandlerTests.cs
+++ b/test/UnitTests/RefreshTokenDelegatingHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -104,6 +105,23 @@ namespace IdentityModel.UnitTests
             refreshHandler.RefreshToken
                 .Should()
                 .Be("refresh_token", "Refresh token should be retained if token response contains only access token");
+        }
+
+        [Fact]
+        public void Creating_with_token_client_should_not_throw()
+        {
+            var tokenClient = new TokenClient("http://server/token", "client");
+            Action act = () => new RefreshTokenDelegatingHandler(tokenClient, "refresh_token");
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Creating_should_not_throw()
+        {
+            Action act = () => new RefreshTokenDelegatingHandler("http://server/token", "client", "secret", "refresh_token");
+
+            act.Should().NotThrow();
         }
     }
 }


### PR DESCRIPTION
Activating `AccessTokenDelegatingHandler` with null `innerHandler` parameter causes ArgumentNullException in [DelegatingHandler](https://github.com/dotnet/corefx/blob/dbea234b95c8ce39c6a1c0243433de0ea36f91af/src/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs#L44) 

 - Adds failing tests
 - Adds ctor overload that don't take innerHandler
 - Removes optional value from orignal ctors.

Fixes #119 and non-breaking.