### PR TITLE
HttpClientExtensions: usage of HttpMessageInvoker instead of HttpClient

### DIFF
--- a/src/IdentityModel/Client/HttpClientDynamicRegistrationExtensions.cs
+++ b/src/IdentityModel/Client/HttpClientDynamicRegistrationExtensions.cs
@@ -25,7 +25,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<RegistrationResponse> RegisterClientAsync(this HttpClient client, DynamicClientRegistrationRequest request, CancellationToken cancellationToken = default)
+        public static async Task<RegistrationResponse> RegisterClientAsync(this HttpMessageInvoker client, DynamicClientRegistrationRequest request, CancellationToken cancellationToken = default)
         {
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, request.Address)
             {

--- a/src/IdentityModel/Client/HttpClientTokenIntrospectionExtensions.cs
+++ b/src/IdentityModel/Client/HttpClientTokenIntrospectionExtensions.cs
@@ -22,7 +22,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<IntrospectionResponse> IntrospectTokenAsync(this HttpClient client, TokenIntrospectionRequest request, CancellationToken cancellationToken = default)
+        public static async Task<IntrospectionResponse> IntrospectTokenAsync(this HttpMessageInvoker client, TokenIntrospectionRequest request, CancellationToken cancellationToken = default)
         {
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, request.Address);
             httpRequest.Headers.Accept.Clear();
@@ -38,7 +38,7 @@ namespace IdentityModel.Client
             HttpResponseMessage response;
             try
             {
-                response = await client.SendAsync(httpRequest).ConfigureAwait(false);
+                response = await client.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/IdentityModel/Client/HttpClientTokenRequestExtensions.cs
+++ b/src/IdentityModel/Client/HttpClientTokenRequestExtensions.cs
@@ -23,7 +23,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<TokenResponse> RequestClientCredentialsTokenAsync(this HttpClient client, ClientCredentialsTokenRequest request, CancellationToken cancellationToken = default)
+        public static async Task<TokenResponse> RequestClientCredentialsTokenAsync(this HttpMessageInvoker client, ClientCredentialsTokenRequest request, CancellationToken cancellationToken = default)
         {
             request.GrantType = OidcConstants.GrantTypes.ClientCredentials;
 
@@ -39,7 +39,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<TokenResponse> RequestPasswordTokenAsync(this HttpClient client, PasswordTokenRequest request, CancellationToken cancellationToken = default)
+        public static async Task<TokenResponse> RequestPasswordTokenAsync(this HttpMessageInvoker client, PasswordTokenRequest request, CancellationToken cancellationToken = default)
         {
             request.GrantType = OidcConstants.GrantTypes.Password;
 
@@ -57,7 +57,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<TokenResponse> RequestAuthorizationCodeTokenAsync(this HttpClient client, AuthorizationCodeTokenRequest request, CancellationToken cancellationToken = default)
+        public static async Task<TokenResponse> RequestAuthorizationCodeTokenAsync(this HttpMessageInvoker client, AuthorizationCodeTokenRequest request, CancellationToken cancellationToken = default)
         {
             request.GrantType = OidcConstants.GrantTypes.AuthorizationCode;
 
@@ -75,7 +75,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<TokenResponse> RequestRefreshTokenAsync(this HttpClient client, RefreshTokenRequest request, CancellationToken cancellationToken = default)
+        public static async Task<TokenResponse> RequestRefreshTokenAsync(this HttpMessageInvoker client, RefreshTokenRequest request, CancellationToken cancellationToken = default)
         {
             request.GrantType = OidcConstants.GrantTypes.RefreshToken;
 
@@ -92,7 +92,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<TokenResponse> RequestTokenAsync(this HttpClient client, TokenRequest request, CancellationToken cancellationToken = default)
+        public static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, TokenRequest request, CancellationToken cancellationToken = default)
         {
             if (!request.Parameters.ContainsKey(OidcConstants.TokenRequest.GrantType))
             {

--- a/src/IdentityModel/Client/HttpClientTokenRevocationExtensions.cs
+++ b/src/IdentityModel/Client/HttpClientTokenRevocationExtensions.cs
@@ -23,7 +23,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<TokenRevocationResponse> RevokeTokenAsync(this HttpClient client, TokenRevocationRequest request, CancellationToken cancellationToken = default)
+        public static async Task<TokenRevocationResponse> RevokeTokenAsync(this HttpMessageInvoker client, TokenRevocationRequest request, CancellationToken cancellationToken = default)
         {
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, request.Address);
             httpRequest.Headers.Accept.Clear();

--- a/src/IdentityModel/Client/HttpClientUserInfoExtensions.cs
+++ b/src/IdentityModel/Client/HttpClientUserInfoExtensions.cs
@@ -22,7 +22,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<UserInfoResponse> GetUserInfoAsync(this HttpClient client, UserInfoRequest request, CancellationToken cancellationToken = default)
+        public static async Task<UserInfoResponse> GetUserInfoAsync(this HttpMessageInvoker client, UserInfoRequest request, CancellationToken cancellationToken = default)
         {
             if (request.Token.IsMissing()) throw new ArgumentNullException(nameof(request.Token));
 


### PR DESCRIPTION
Hello,

the HttpClientExtension approach is great for working with a shared application HttpClient. 
In order to prevent/ensure HttpClient is not modified by these extensions it would be great if these Extensions would only depend on the base class `HttpMessageInvoker` of HttpClient. 
HttpMessageInvoker only provides the method `Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)` and therefore minimizes the impact on the used HttpClient.

Best regards,
peter