### PR TITLE
Add support for extra param when using client credentials access token

### DIFF
--- a/src/Client/AccessTokenDelegatingHandler.cs
+++ b/src/Client/AccessTokenDelegatingHandler.cs
@@ -19,6 +19,7 @@ namespace IdentityModel.Client
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
         private readonly TokenClient _tokenClient;
         private readonly string _scope;
+        private readonly object _extra;
 
         private string _accessToken;
         private bool _disposed;
@@ -103,6 +104,22 @@ namespace IdentityModel.Client
             _scope = scope;
         }
 
+        /// /// <summary>
+        /// Initializes a new instance of the <see cref="AccessTokenDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="extra">Extra parameters.</param>
+        /// <param name="innerHandler">The inner handler.</param>
+        public AccessTokenDelegatingHandler(TokenClient client, string scope, object extra, HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+            _tokenClient = client;
+            _scope = scope;
+            _extra = extra;
+        }
+
+
         /// <summary>
         /// Sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
         /// </summary>
@@ -161,7 +178,7 @@ namespace IdentityModel.Client
             {
                 try
                 {
-                    var response = await _tokenClient.RequestClientCredentialsAsync(_scope, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var response = await _tokenClient.RequestClientCredentialsAsync(_scope, _extra, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                     if (!response.IsError)
                     {


### PR DESCRIPTION
I noticed that when I attempted to use AccessTokenDelegatingHandler with Auth0 I wasn't able to pass in some extra properties on the body of the token request. Auth0 requires the presence of the audience property.

This PR will add support for the extra object that can be used to pass in arbitrary properties on the body of the renew token request.