### PR TITLE
The Error of namespace

### DIFF
--- a/src/Internal/DictionaryExtensions.cs
+++ b/src/Internal/DictionaryExtensions.cs
@@ -15,14 +15,31 @@ namespace IdentityModel.Internal
 
         public static void AddOptional(this IDictionary<string, string> dictionary, string key, string value)
         {
-            if (value.IsPresent()) dictionary.Add(key, value);
+            if (value.IsPresent())
+            {
+                if (dictionary.ContainsKey(key))
+                {
+                    throw new InvalidOperationException($"Duplicate parameter: {key}");
+                }
+                else
+                {
+                    dictionary.Add(key, value);
+                }
+            }
         }
 
         public static void AddRequired(this IDictionary<string, string> dictionary, string key, string value, bool allowEmpty = false)
         {
             if (value.IsPresent())
             {
-                dictionary.Add(key, value);
+                if (dictionary.ContainsKey(key))
+                {
+                    throw new InvalidOperationException($"Duplicate parameter: {key}");
+                }
+                else
+                {
+                    dictionary.Add(key, value);
+                }
             }
             else
             {


### PR DESCRIPTION
Just now I want to use the class named "DiscoveryClient", but I found that I can not find it in the namespace "IdentityModel.Client". Then I found there is a folder named "old" and the class is actually in the namespace of old.