### PR TITLE
Target HttpMessageInvoker instead of HttpClient in discovery methods

### DIFF
--- a/src/Client/DiscoveryCache.cs
+++ b/src/Client/DiscoveryCache.cs
@@ -17,7 +17,7 @@ namespace IdentityModel.Client
         private AsyncLazy<DiscoveryDocumentResponse> _lazyResponse;
 
         private readonly DiscoveryPolicy _policy;
-        private readonly Func<HttpClient> _getHttpClient;
+        private readonly Func<HttpMessageInvoker> _getHttpClient;
         private readonly string _authority;
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace IdentityModel.Client
         /// <param name="authority">Base address or discovery document endpoint.</param>
         /// <param name="httpClientFunc">The HTTP client function.</param>
         /// <param name="policy">The policy.</param>
-        public DiscoveryCache(string authority, Func<HttpClient> httpClientFunc, DiscoveryPolicy policy = null)
+        public DiscoveryCache(string authority, Func<HttpMessageInvoker> httpClientFunc, DiscoveryPolicy policy = null)
         {
             _authority = authority;
             _policy = policy ?? new DiscoveryPolicy();

--- a/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
+++ b/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
@@ -47,10 +47,10 @@ namespace IdentityModel.Client
             {
                 address = ((HttpClient)client).BaseAddress.AbsoluteUri;
             }
-			else
-			{
-				throw new ArgumentException("An address is required.");
-			}
+            else
+            {
+                throw new ArgumentException("An address is required.");
+            }
 
             var parsed = DiscoveryEndpoint.ParseUrl(address);
             var authority = parsed.Authority;
@@ -98,22 +98,22 @@ namespace IdentityModel.Client
                     jwkUrl = disco.JwksUri;
                     if (jwkUrl != null)
                     {
-						using (HttpRequestMessage getRequest = new HttpRequestMessage(HttpMethod.Get, jwkUrl))
-						{
-							response = await client.SendAsync(getRequest, cancellationToken).ConfigureAwait(false);
+                        using (HttpRequestMessage getRequest = new HttpRequestMessage(HttpMethod.Get, jwkUrl))
+                        {
+                            response = await client.SendAsync(getRequest, cancellationToken).ConfigureAwait(false);
 
-							if (response.Content != null)
-							{
-								responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-							}
+                            if (response.Content != null)
+                            {
+                                responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            }
 
-							if (!response.IsSuccessStatusCode)
-							{
-								return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, $"Error connecting to {jwkUrl}: {response.ReasonPhrase}").ConfigureAwait(false);
-							}
+                            if (!response.IsSuccessStatusCode)
+                            {
+                                return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, $"Error connecting to {jwkUrl}: {response.ReasonPhrase}").ConfigureAwait(false);
+                            }
 
-							disco.KeySet = new JsonWebKeySet(responseContent);
-						}
+                            disco.KeySet = new JsonWebKeySet(responseContent);
+                        }
                     }
 
                     return disco;

--- a/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
+++ b/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
@@ -34,7 +34,7 @@ namespace IdentityModel.Client
         /// <param name="request">The request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public static async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(this HttpClient client, DiscoveryDocumentRequest request = null, CancellationToken cancellationToken = default)
+        public static async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(this HttpMessageInvoker client, DiscoveryDocumentRequest request = null, CancellationToken cancellationToken = default)
         {
             if (request == null) request = new DiscoveryDocumentRequest();
 
@@ -43,10 +43,14 @@ namespace IdentityModel.Client
             {
                 address = request.Address;
             }
-            else
+            else if (client is HttpClient)
             {
-                address = client.BaseAddress.AbsoluteUri;
+                address = ((HttpClient)client).BaseAddress.AbsoluteUri;
             }
+			else
+			{
+				throw new ArgumentException("An address is required.");
+			}
 
             var parsed = DiscoveryEndpoint.ParseUrl(address);
             var authority = parsed.Authority;
@@ -94,19 +98,22 @@ namespace IdentityModel.Client
                     jwkUrl = disco.JwksUri;
                     if (jwkUrl != null)
                     {
-                        response = await client.GetAsync(jwkUrl, cancellationToken).ConfigureAwait(false);
+						using (HttpRequestMessage getRequest = new HttpRequestMessage(HttpMethod.Get, jwkUrl))
+						{
+							response = await client.SendAsync(getRequest, cancellationToken).ConfigureAwait(false);
 
-                        if (response.Content != null)
-                        {
-                            responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        }
+							if (response.Content != null)
+							{
+								responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+							}
 
-                        if (!response.IsSuccessStatusCode)
-                        {
-                            return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, $"Error connecting to {jwkUrl}: {response.ReasonPhrase}").ConfigureAwait(false);
-                        }
+							if (!response.IsSuccessStatusCode)
+							{
+								return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(response, $"Error connecting to {jwkUrl}: {response.ReasonPhrase}").ConfigureAwait(false);
+							}
 
-                        disco.KeySet = new JsonWebKeySet(responseContent);
+							disco.KeySet = new JsonWebKeySet(responseContent);
+						}
                     }
 
                     return disco;

--- a/src/Client/TokenClient.cs
+++ b/src/Client/TokenClient.cs
@@ -11,7 +11,7 @@ namespace IdentityModel.Client
     /// </summary>
     public class TokenClient
     {
-        private readonly HttpClient _client;
+        private readonly HttpMessageInvoker _client;
         private readonly TokenClientOptions _options;
 
         /// <summary>
@@ -20,7 +20,7 @@ namespace IdentityModel.Client
         /// <param name="client">The client.</param>
         /// <param name="options">The options.</param>
         /// <exception cref="ArgumentNullException">client</exception>
-        public TokenClient(HttpClient client, TokenClientOptions options)
+        public TokenClient(HttpMessageInvoker client, TokenClientOptions options)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _options = options ?? new TokenClientOptions();


### PR DESCRIPTION
This pull request refactors all discovery-related methods to target HttpMessageInvoker instead of HttpClient.
Solves issue #178 as far as I'm concerned