### PR TITLE
Restore FireAndForget method to notify subscribers about the event

### DIFF
--- a/src/Client/AccessTokenDelegatingHandler.cs
+++ b/src/Client/AccessTokenDelegatingHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using IdentityModel.Internal;
@@ -55,7 +55,7 @@ namespace IdentityModel.Client
         /// <summary>
         /// Occurs when the tokens were renewed successfully
         /// </summary>
-        public event EventHandler<TokenRenewedEventArgs> TokenRenewed = delegate { };
+        public event EventHandler<TokenRenewedEventArgs> TokenRenewed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AccessTokenDelegatingHandler"/> class.
@@ -184,19 +184,7 @@ namespace IdentityModel.Client
                     {
                         _accessToken = response.AccessToken;
 
-#pragma warning disable 4014
-                        Task.Run(() =>
-                        {
-                            foreach (EventHandler<TokenRenewedEventArgs> del in TokenRenewed.GetInvocationList())
-                            {
-                                try
-                                {
-                                    del(this, new TokenRenewedEventArgs(response.AccessToken, response.ExpiresIn));
-                                }
-                                catch { }
-                            }
-                        }).ConfigureAwait(false);
-#pragma warning restore 4014
+                        TokenRenewed?.FireAndForget(this, new TokenRenewedEventArgs(response.AccessToken, response.ExpiresIn));
 
                         return true;
                     }

--- a/src/Client/Old/AccessTokenHandler.cs
+++ b/src/Client/Old/AccessTokenHandler.cs
@@ -30,7 +30,7 @@ namespace IdentityModel.Client
         /// Gets or sets the timeout
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
-        
+
         /// <summary>
         /// Gets the current access token
         /// </summary>
@@ -57,7 +57,7 @@ namespace IdentityModel.Client
         /// <summary>
         /// Occurs when the tokens were renewed successfully
         /// </summary>
-        public event EventHandler<TokenRenewedEventArgs> TokenRenewed = delegate { };
+        public event EventHandler<TokenRenewedEventArgs> TokenRenewed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AccessTokenHandler"/> class.
@@ -149,19 +149,7 @@ namespace IdentityModel.Client
                     {
                         _accessToken = response.AccessToken;
 
-#pragma warning disable 4014
-                        Task.Run(() =>
-                        {
-                            foreach (EventHandler<TokenRenewedEventArgs> del in TokenRenewed.GetInvocationList())
-                            {
-                                try
-                                {
-                                    del(this, new TokenRenewedEventArgs(response.AccessToken, response.ExpiresIn));
-                                }
-                                catch { }
-                            }
-                        }).ConfigureAwait(false);
-#pragma warning restore 4014
+                        TokenRenewed?.FireAndForget(this, new TokenRenewedEventArgs(response.AccessToken, response.ExpiresIn));
 
                         return true;
                     }

--- a/src/Client/Old/RefreshTokenHandler.cs
+++ b/src/Client/Old/RefreshTokenHandler.cs
@@ -29,7 +29,7 @@ namespace IdentityModel.Client
         /// Gets or sets the timeout
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
-        
+
         /// <summary>
         /// Gets the current access token
         /// </summary>
@@ -79,7 +79,7 @@ namespace IdentityModel.Client
         /// <summary>
         /// Occurs when the tokens were refreshed successfully
         /// </summary>
-        public event EventHandler<TokenRefreshedEventArgs> TokenRefreshed = delegate { };
+        public event EventHandler<TokenRefreshedEventArgs> TokenRefreshed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshTokenHandler"/> class.
@@ -184,19 +184,7 @@ namespace IdentityModel.Client
                             _refreshToken = response.RefreshToken;
                         }
 
-#pragma warning disable 4014
-                        Task.Run(() =>
-                        {
-                            foreach (EventHandler<TokenRefreshedEventArgs> del in TokenRefreshed.GetInvocationList())
-                            {
-                                try
-                                {
-                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, (int)response.ExpiresIn));
-                                }
-                                catch { }
-                            }
-                        }).ConfigureAwait(false);
-#pragma warning restore 4014
+                        TokenRefreshed?.FireAndForget(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.ExpiresIn));
 
                         return true;
                     }

--- a/src/Client/RefreshTokenDelegatingHandler.cs
+++ b/src/Client/RefreshTokenDelegatingHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using IdentityModel.Internal;
@@ -77,7 +77,7 @@ namespace IdentityModel.Client
         /// <summary>
         /// Occurs when the tokens were refreshed successfully
         /// </summary>
-        public event EventHandler<TokenRefreshedEventArgs> TokenRefreshed = delegate { };
+        public event EventHandler<TokenRefreshedEventArgs> TokenRefreshed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshTokenDelegatingHandler"/> class.
@@ -253,19 +253,7 @@ namespace IdentityModel.Client
                             _refreshToken = response.RefreshToken;
                         }
 
-#pragma warning disable 4014
-                        Task.Run(() =>
-                        {
-                            foreach (EventHandler<TokenRefreshedEventArgs> del in TokenRefreshed.GetInvocationList())
-                            {
-                                try
-                                {
-                                    del(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, (int)response.ExpiresIn));
-                                }
-                                catch { }
-                            }
-                        }).ConfigureAwait(false);
-#pragma warning restore 4014
+                        TokenRefreshed?.FireAndForget(this, new TokenRefreshedEventArgs(response.AccessToken, response.RefreshToken, response.ExpiresIn));
 
                         return true;
                     }

--- a/src/Internal/EventExtensions.cs
+++ b/src/Internal/EventExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel
+{
+    /// <summary>
+    /// Extensions for EventHandler<TEventArgs>
+    /// </summary>
+    internal static class EventExtensions
+    {
+        public static void FireAndForget<TEventArgs>(this EventHandler<TEventArgs> theEvent, object sender, TEventArgs eventArgs)
+        {
+            if (theEvent == null) throw new ArgumentNullException(nameof(theEvent));
+
+            var subscribers = theEvent.GetInvocationList();
+            if (subscribers.Length > 0)
+            {
+                Task.Run(() =>
+                {
+                    foreach (EventHandler<TEventArgs> subscriber in subscribers)
+                    {
+                        try
+                        {
+                            subscriber.Invoke(sender, eventArgs);
+                        }
+                        catch
+                        {
+                        }
+                    }
+                }, CancellationToken.None);
+            }
+        }
+    }
+}

--- a/src/Internal/EventExtensions.cs
+++ b/src/Internal/EventExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
Purposes:
* Do not repeat the code
* Do not call Task.Run() if there are no subscribers

PS: rollback the following commit https://github.com/IdentityModel/IdentityModel2/commit/f56ef26c878b0c5d42f0cf72a5bd8a929504c796