### PR TITLE
Use GetAccessTokenAsync method instead of AccessToken property

### DIFF
--- a/src/Client/AccessTokenDelegatingHandler.cs
+++ b/src/Client/AccessTokenDelegatingHandler.cs
@@ -28,10 +28,11 @@ namespace IdentityModel.Client
         /// Gets or sets the timeout
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
-        
+
         /// <summary>
         /// Gets the current access token
         /// </summary>
+        [Obsolete("Please, use GetAccessTokenAsync() method instead.")]
         public string AccessToken
         {
             get
@@ -130,16 +131,20 @@ namespace IdentityModel.Client
         /// </returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var accessToken = await GetAccessTokenAsync(cancellationToken);
+            var accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             if (accessToken.IsMissing())
             {
-                if (await RenewTokensAsync(cancellationToken) == false)
+                if (await RenewTokensAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
                 {
                     return new HttpResponseMessage(HttpStatusCode.Unauthorized) {RequestMessage = request};
                 }
             }
 
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.Unauthorized)
@@ -147,14 +152,18 @@ namespace IdentityModel.Client
                 return response;
             }
 
-            if (await RenewTokensAsync(cancellationToken) == false)
+            if (await RenewTokensAsync(cancellationToken).ConfigureAwait(false))
+            {
+                accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
             {
                 return response;
             }
 
             response.Dispose(); // This 401 response will not be used for anything so is disposed to unblock the socket.
 
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Client/Old/AccessTokenHandler.cs
+++ b/src/Client/Old/AccessTokenHandler.cs
@@ -30,10 +30,11 @@ namespace IdentityModel.Client
         /// Gets or sets the timeout
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
-        
+
         /// <summary>
         /// Gets the current access token
         /// </summary>
+        [Obsolete("Please, use GetAccessTokenAsync() method instead.")]
         public string AccessToken
         {
             get
@@ -95,16 +96,20 @@ namespace IdentityModel.Client
         /// </returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var accessToken = await GetAccessTokenAsync(cancellationToken);
+            var accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             if (accessToken.IsMissing())
             {
-                if (await RenewTokensAsync(cancellationToken) == false)
+                if (await RenewTokensAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
                 {
                     return new HttpResponseMessage(HttpStatusCode.Unauthorized) {RequestMessage = request};
                 }
             }
 
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.Unauthorized)
@@ -112,14 +117,18 @@ namespace IdentityModel.Client
                 return response;
             }
 
-            if (await RenewTokensAsync(cancellationToken) == false)
+            if (await RenewTokensAsync(cancellationToken).ConfigureAwait(false))
+            {
+                accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
             {
                 return response;
             }
 
             response.Dispose(); // This 401 response will not be used for anything so is disposed to unblock the socket.
 
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Client/RefreshTokenDelegatingHandler.cs
+++ b/src/Client/RefreshTokenDelegatingHandler.cs
@@ -27,10 +27,11 @@ namespace IdentityModel.Client
         /// Gets or sets the timeout
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
-        
+
         /// <summary>
         /// Gets the current access token
         /// </summary>
+        [Obsolete("Please, use GetAccessTokenAsync() method instead.")]
         public string AccessToken
         {
             get
@@ -189,16 +190,20 @@ namespace IdentityModel.Client
         /// </returns>
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var accessToken = await GetAccessTokenAsync(cancellationToken);
+            var accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             if (accessToken.IsMissing())
             {
-                if (await RefreshTokensAsync(cancellationToken) == false)
+                if (await RefreshTokensAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
                 {
                     return new HttpResponseMessage(HttpStatusCode.Unauthorized) {RequestMessage = request};
                 }
             }
 
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.Unauthorized)
@@ -206,14 +211,18 @@ namespace IdentityModel.Client
                 return response;
             }
 
-            if (await RefreshTokensAsync(cancellationToken) == false)
+            if (await RefreshTokensAsync(cancellationToken).ConfigureAwait(false))
+            {
+                accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
             {
                 return response;
             }
 
             response.Dispose(); // This 401 response will not be used for anything so is disposed to unblock the socket.
 
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Purposes:
* Use GetAccessTokenAsync method instead of AccessToken property in order to have less blocking 
* Use .ConfigureAwait(false) for async methods