### PR TITLE
Introduce AuthenticationCache to share auth tokens between HttpClients

### DIFF
--- a/samples/HttpClientFactorySample/WebApplication1/Controllers/DemoIdentityServerController.cs
+++ b/samples/HttpClientFactorySample/WebApplication1/Controllers/DemoIdentityServerController.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityModel.Client;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApplication1.Controllers
+{
+    public class DemoIdentityServerController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+
+        public Task<string> UseTypedClient([FromServices] DemoIdentityServerClient demoClient, CancellationToken cancellationToken)
+        {
+            return demoClient.GetTest(cancellationToken);
+        }
+    }
+}

--- a/samples/HttpClientFactorySample/WebApplication1/Controllers/HomeController.cs
+++ b/samples/HttpClientFactorySample/WebApplication1/Controllers/HomeController.cs
@@ -7,61 +7,56 @@ namespace WebApplication1.Controllers
 {
     public class HomeController : Controller
     {
-        public HomeController(IHttpClientFactory httpClientFactory)
-        {
-            HttpClientFactory = httpClientFactory;
-        }
-
-        public IHttpClientFactory HttpClientFactory { get; }
-        public TokenClient TokenClient { get; }
-
         public IActionResult Index()
         {
             return View();
         }
 
-        public async Task<string> NoFactory()
+        public async Task<string> UseNativeHttpClient()
         {
-            var client = new HttpClient();
-
-            var response = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+            using (var client = new HttpClient())
             {
-                Address = "https://demo.identityserver.io/connect/token",
-                ClientId = "client",
-                ClientSecret = "secret"
-            });
+                var response = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+                {
+                    Address = "https://demo.identityserver.io/connect/token",
+                    ClientId = "client",
+                    ClientSecret = "secret"
+                });
 
-            return response.AccessToken ?? response.Error;
+                return response.AccessToken ?? response.Error;
+            }
         }
 
-        public async Task<string> Simple()
+        public async Task<string> UseHttpClientFactory([FromServices] IHttpClientFactory httpClientFactory)
         {
-            var client = HttpClientFactory.CreateClient();
-
-            var response = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+            using (var client = httpClientFactory.CreateClient())
             {
-                Address = "https://demo.identityserver.io/connect/token",
-                ClientId = "client",
-                ClientSecret = "secret"
-            });
+                var response = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+                {
+                    Address = "https://demo.identityserver.io/connect/token",
+                    ClientId = "client",
+                    ClientSecret = "secret"
+                });
 
-            return response.AccessToken ?? response.Error;
+                return response.AccessToken ?? response.Error;
+            }
         }
 
-        public async Task<string> WithAddress()
+        public async Task<string> UseHttpClientFactoryWithName([FromServices] IHttpClientFactory httpClientFactory)
         {
-            var client = HttpClientFactory.CreateClient("token_client");
-
-            var response = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+            using (var client = httpClientFactory.CreateClient("token_client"))
             {
-                ClientId = "client",
-                ClientSecret = "secret"
-            });
+                var response = await client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+                {
+                    ClientId = "client",
+                    ClientSecret = "secret"
+                });
 
-            return response.AccessToken ?? response.Error;
+                return response.AccessToken ?? response.Error;
+            }
         }
 
-        public async Task<string> Typed([FromServices] TokenClient tokenClient)
+        public async Task<string> UseTypedClient([FromServices] TokenClient tokenClient)
         {
             return await tokenClient.GetToken();
         }

--- a/samples/HttpClientFactorySample/WebApplication1/DemoIdentityServerClient.cs
+++ b/samples/HttpClientFactorySample/WebApplication1/DemoIdentityServerClient.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WebApplication1
+{
+    public sealed class DemoIdentityServerClient
+    {
+        public DemoIdentityServerClient(HttpClient client)
+        {
+            Client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public HttpClient Client { get; }
+
+        public async Task<string> GetTest(CancellationToken cancellationToken)
+        {
+            using (var response = await Client.GetAsync("api/test", cancellationToken).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/samples/HttpClientFactorySample/WebApplication1/Views/DemoIdentityServer/Index.cshtml
+++ b/samples/HttpClientFactorySample/WebApplication1/Views/DemoIdentityServer/Index.cshtml
@@ -1,0 +1,6 @@
+<h1>Demo IdentityServer API</h1>
+
+<div>
+    <h2>using TypedClient with AuthenticateDelegatingHandler</h2>
+    <span data-load="@Url.Content("~/DemoIdentityServer/UseTypedClient")">Loading...</span>
+</div>

--- a/samples/HttpClientFactorySample/WebApplication1/Views/Home/Index.cshtml
+++ b/samples/HttpClientFactorySample/WebApplication1/Views/Home/Index.cshtml
@@ -1,1 +1,21 @@
-﻿<h1>HttpClientFactory sample</h1>
+﻿<h1>Request ClientCredentials</h1>
+
+<div>
+    <h2>using HttpClient</h2>
+    <span data-load="@Url.Content("~/Home/UseNativeHttpClient")">Loading...</span>
+</div>
+
+<div>
+    <h2>using HttpClientFactory</h2>
+    <span data-load="@Url.Content("~/Home/UseHttpClientFactory")">Loading...</span>
+</div>
+
+<div>
+    <h2>using HttpClientFactory with name</h2>
+    <span data-load="@Url.Content("~/Home/UseHttpClientFactoryWithName")">Loading...</span>
+</div>
+
+<div>
+    <h2>using TypedClient</h2>
+    <span data-load="@Url.Content("~/Home/UseTypedClient")">Loading...</span>
+</div>

--- a/samples/HttpClientFactorySample/WebApplication1/Views/Shared/_Layout.cshtml
+++ b/samples/HttpClientFactorySample/WebApplication1/Views/Shared/_Layout.cshtml
@@ -31,8 +31,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a asp-area="" asp-controller="Home" asp-action="Index">Home</a></li>
-                    <li><a asp-area="" asp-controller="Home" asp-action="About">About</a></li>
-                    <li><a asp-area="" asp-controller="Home" asp-action="Contact">Contact</a></li>
+                    <li><a asp-area="" asp-controller="DemoIdentityServer" asp-action="Index">Demo IdentityServer</a></li>
                 </ul>
             </div>
         </div>

--- a/samples/HttpClientFactorySample/WebApplication1/wwwroot/js/site.js
+++ b/samples/HttpClientFactorySample/WebApplication1/wwwroot/js/site.js
@@ -1,4 +1,9 @@
 ﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
-// Write your JavaScript code.
+$(function() {
+    $("[data-load]").each(function() {
+        var $el = $(this);
+        $el.load($el.attr("data-load"));
+    })
+})

--- a/src/Client/AuthenticateDelegatingHandler.cs
+++ b/src/Client/AuthenticateDelegatingHandler.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityModel.Internal;
+
+namespace IdentityModel.Client
+{
+    /// <inheritdoc />
+    public sealed class AuthenticateDelegatingHandler : DelegatingHandler
+    {
+        private readonly IAuthenticationCache _authenticationCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticateDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="authenticationCache">The authentication cache.</param>
+        public AuthenticateDelegatingHandler(IAuthenticationCache authenticationCache)
+        {
+            _authenticationCache = authenticationCache ?? throw new ArgumentNullException(nameof(authenticationCache));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticateDelegatingHandler" /> class.
+        /// </summary>
+        /// <param name="authenticationCache">The authentication cache.</param>
+        /// <param name="innerHandler">The inner handler.</param>
+        public AuthenticateDelegatingHandler(IAuthenticationCache authenticationCache, HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+            _authenticationCache = authenticationCache ?? throw new ArgumentNullException(nameof(authenticationCache));
+        }
+
+        /// <inheritdoc />
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var accessToken = _authenticationCache.AccessToken;
+            if (accessToken.IsMissing())
+            {
+                if (await _authenticationCache.RotateAsync(accessToken, cancellationToken).ConfigureAwait(false))
+                {
+                    accessToken = _authenticationCache.AccessToken;
+                }
+                else
+                {
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized) {RequestMessage = request};
+                }
+            }
+
+            request.Headers.Authorization = new AuthenticationHeaderValue(_authenticationCache.TokenType, accessToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                return response;
+            }
+
+            if (await _authenticationCache.RotateAsync(accessToken, cancellationToken).ConfigureAwait(false))
+            {
+                accessToken = _authenticationCache.AccessToken;
+            }
+            else
+            {
+                return response;
+            }
+
+            response.Dispose(); // This 401 response will not be used for anything so is disposed to unblock the socket.
+
+            request.Headers.Authorization = new AuthenticationHeaderValue(_authenticationCache.TokenType, accessToken);
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Client/AuthenticationCache.cs
+++ b/src/Client/AuthenticationCache.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityModel.Internal;
+
+namespace IdentityModel.Client
+{
+    /// <inheritdoc />
+    public sealed class AuthenticationCache : IAuthenticationCache, IDisposable
+    {
+        private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+        private readonly IAuthenticationProvider _authenticationProvider;
+        private string _accessToken;
+        private string _refreshToken;
+
+        /// <summary>
+        /// Occurs when the tokens were received successfully
+        /// </summary>
+        public event EventHandler<TokenReceivedEventArgs> TokenReceived;
+
+        /// <summary>
+        /// Gets or sets the timeout
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
+
+        /// <inheritdoc />
+        public string TokenType { get; set; } = OidcConstants.TokenResponse.BearerTokenType;
+
+        /// <inheritdoc />
+        public string AccessToken => _accessToken;
+
+        /// <inheritdoc />
+        public string RefreshToken => _refreshToken;
+
+        /// /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationCache"/> class.
+        /// </summary>
+        /// <param name="authenticationProvider">The authentication provider.</param>
+        /// <param name="refreshToken">The refresh token.</param>
+        /// <param name="accessToken">The access token.</param>
+        public AuthenticationCache(IAuthenticationProvider authenticationProvider, string refreshToken = null, string accessToken = null)
+        {
+            _authenticationProvider = authenticationProvider ?? throw new ArgumentNullException(nameof(authenticationProvider));
+            _refreshToken = refreshToken;
+            _accessToken = accessToken;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _lock?.Dispose();
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> UpdateAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var request = _refreshToken.IsMissing()
+                    ? _authenticationProvider.RequestTokenAsync(cancellationToken)
+                    : _authenticationProvider.RefreshTokenAsync(_refreshToken, cancellationToken);
+
+                var response = await request.ConfigureAwait(false);
+                if (response.IsError)
+                {
+                    return false;
+                }
+
+                Interlocked.Exchange(ref _accessToken, response.AccessToken);
+                if (!response.RefreshToken.IsMissing())
+                {
+                    Interlocked.Exchange(ref _refreshToken, response.RefreshToken);
+                }
+
+                TokenReceived?.Invoke(this, new TokenReceivedEventArgs(response.AccessToken, response.RefreshToken));
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> RotateAsync(string accessToken, CancellationToken cancellationToken = default)
+        {
+            if (_accessToken == accessToken)
+            {
+                if (await _lock.WaitAsync(Timeout, cancellationToken).ConfigureAwait(false))
+                {
+                    try
+                    {
+                        if (_accessToken == accessToken)
+                        {
+                            return await UpdateAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    finally
+                    {
+                        _lock.Release();
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/Client/AuthorizationCodeProvider.cs
+++ b/src/Client/AuthorizationCodeProvider.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.Client
+{
+    /// <inheritdoc />
+    public sealed class AuthorizationCodeProvider : IAuthenticationProvider, IDisposable
+    {
+        private readonly TokenClient _tokenClient;
+        private readonly bool _disposeTokenClient;
+        private readonly string _code;
+        private readonly string _redirectUri;
+        private readonly string _codeVerifier;
+        private readonly object _extra;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorizationCodeProvider"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="code">The code.</param>
+        /// <param name="redirectUri">The redirect URI.</param>
+        /// <param name="codeVerifier">The code verifier.</param>
+        /// <param name="extra">Extra parameters.</param>
+        public AuthorizationCodeProvider(string tokenEndpoint, string clientId, string clientSecret, string code, string redirectUri, string codeVerifier = null, object extra = null)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), code, redirectUri, codeVerifier, extra, disposeTokenClient: true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthorizationCodeProvider"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="code">The code.</param>
+        /// <param name="redirectUri">The redirect URI.</param>
+        /// <param name="codeVerifier">The code verifier.</param>
+        /// <param name="extra">Extra parameters.</param>
+        public AuthorizationCodeProvider(TokenClient client, string code, string redirectUri, string codeVerifier = null, object extra = null, bool disposeTokenClient = false)
+        {
+            _tokenClient = client ?? throw new ArgumentNullException(nameof(client));
+            _disposeTokenClient = disposeTokenClient;
+            _code = code ?? throw new ArgumentNullException(nameof(code));
+            _redirectUri = redirectUri ?? throw new ArgumentNullException(nameof(redirectUri));
+            _codeVerifier = codeVerifier;
+            _extra = extra;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposeTokenClient)
+            {
+                _tokenClient?.Dispose();
+            }
+        }
+
+        /// <inheritdoc />
+        public Task<TokenResponse> RequestTokenAsync(CancellationToken cancellationToken = default)
+        {
+            return _tokenClient.RequestAuthorizationCodeAsync(_code, _redirectUri, _codeVerifier, _extra, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<TokenResponse> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
+        {
+            return _tokenClient.RequestRefreshTokenAsync(refreshToken, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/src/Client/ClientCredentialsProvider.cs
+++ b/src/Client/ClientCredentialsProvider.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.Client
+{
+    /// <inheritdoc />
+    public sealed class ClientCredentialsProvider : IAuthenticationProvider, IDisposable
+    {
+        private readonly TokenClient _tokenClient;
+        private readonly bool _disposeTokenClient;
+        private readonly string _scope;
+        private readonly object _extra;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientCredentialsProvider"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="extra">Extra parameters.</param>
+        public ClientCredentialsProvider(string tokenEndpoint, string clientId, string clientSecret, string scope = null, object extra = null)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), scope, extra, disposeTokenClient: true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientCredentialsProvider"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="extra">Extra parameters.</param>
+        public ClientCredentialsProvider(TokenClient client, string scope = null, object extra = null, bool disposeTokenClient = false)
+        {
+            _tokenClient = client ?? throw new ArgumentNullException(nameof(client));
+            _disposeTokenClient = disposeTokenClient;
+            _scope = scope;
+            _extra = extra;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposeTokenClient)
+            {
+                _tokenClient?.Dispose();
+            }
+        }
+
+        /// <inheritdoc />
+        public Task<TokenResponse> RequestTokenAsync(CancellationToken cancellationToken = default)
+        {
+            return _tokenClient.RequestClientCredentialsAsync(_scope, _extra, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<TokenResponse> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
+        {
+            return _tokenClient.RequestRefreshTokenAsync(refreshToken, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/src/Client/IAuthenticationCache.cs
+++ b/src/Client/IAuthenticationCache.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.Client
+{
+    /// <summary>
+    /// Interface for authentication cache.
+    /// </summary>
+    public interface IAuthenticationCache
+    {
+        /// <summary>
+        /// Gets the token type a.k.a authorization schema
+        /// </summary>
+        string TokenType { get; }
+
+        /// <summary>
+        /// Gets the access token.
+        /// </summary>
+        string AccessToken { get; }
+
+        /// <summary>
+        /// Gets the refresh token.
+        /// </summary>
+        string RefreshToken { get; }
+
+        /// <summary>
+        /// Updates tokens.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Returns <see langword="true" /> if success; otherwise, <see langword="false" />.</returns>
+        Task<bool> UpdateAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Rotates tokens if access tokens are equal.
+        /// </summary>
+        /// <param name="accessToken">The access token.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Returns <see langword="true" /> if success; otherwise, <see langword="false" />.</returns>
+        Task<bool> RotateAsync(string accessToken, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Client/IAuthenticationProvider.cs
+++ b/src/Client/IAuthenticationProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.Client
+{
+    /// <summary>
+    /// Interface for authentication provider.
+    /// </summary>
+    public interface IAuthenticationProvider
+    {
+        /// <summary>
+        /// Requests a token.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Returns a token response.</returns>
+        Task<TokenResponse> RequestTokenAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Refreshes a token.
+        /// </summary>
+        /// <param name="refreshToken">The refresh token.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Returns a token response.</returns>
+        Task<TokenResponse> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Client/ResourceOwnerPasswordProvider.cs
+++ b/src/Client/ResourceOwnerPasswordProvider.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.Client
+{
+    /// <inheritdoc />
+    public sealed class ResourceOwnerPasswordProvider : IAuthenticationProvider, IDisposable
+    {
+        private readonly TokenClient _tokenClient;
+        private readonly string _userName;
+        private readonly string _password;
+        private readonly string _scope;
+        private readonly object _extra;
+        private readonly bool _disposeTokenClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceOwnerPasswordProvider"/> class.
+        /// </summary>
+        /// <param name="tokenEndpoint">The token endpoint.</param>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="clientSecret">The client secret.</param>
+        /// <param name="userName">Name of the user.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="extra">Extra parameters.</param>
+        public ResourceOwnerPasswordProvider(string tokenEndpoint, string clientId, string clientSecret, string userName, string password, string scope = null, object extra = null)
+            : this(new TokenClient(tokenEndpoint, clientId, clientSecret), userName, password, scope, extra, disposeTokenClient: true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceOwnerPasswordProvider"/> class.
+        /// </summary>
+        /// <param name="client">The client.</param>
+        /// <param name="userName">Name of the user.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="scope">The scope.</param>
+        /// <param name="extra">Extra parameters.</param>
+        public ResourceOwnerPasswordProvider(TokenClient client, string userName, string password, string scope = null, object extra = null, bool disposeTokenClient = false)
+        {
+            _tokenClient = client ?? throw new ArgumentNullException(nameof(client));
+            _disposeTokenClient = disposeTokenClient;
+            _userName = userName ?? throw new ArgumentNullException(nameof(userName));
+            _password = password ?? throw new ArgumentNullException(nameof(password));
+            _scope = scope;
+            _extra = extra;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposeTokenClient)
+            {
+                _tokenClient?.Dispose();
+            }
+        }
+
+        /// <inheritdoc />
+        public Task<TokenResponse> RequestTokenAsync(CancellationToken cancellationToken = default)
+        {
+            return _tokenClient.RequestResourceOwnerPasswordAsync(_userName, _password, _scope, _extra, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<TokenResponse> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
+        {
+            return _tokenClient.RequestRefreshTokenAsync(refreshToken, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/src/Client/TokenReceivedEventArgs.cs
+++ b/src/Client/TokenReceivedEventArgs.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+
+namespace IdentityModel.Client
+{
+    /// <summary>
+    /// Event argument with the received token
+    /// </summary>
+    public class TokenReceivedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokenReceivedEventArgs" /> class.
+        /// </summary>
+        /// <param name="accessToken">The access token.</param>
+        /// <param name="refreshToken">The refresh token.</param>
+        public TokenReceivedEventArgs(string accessToken, string refreshToken)
+        {
+            AccessToken = accessToken;
+            RefreshToken = refreshToken;
+        }
+
+        /// <summary>
+        /// Gets the access token.
+        /// </summary>
+        /// <value>
+        /// The access token.
+        /// </value>
+        public string AccessToken { get; }
+
+        /// <summary>
+        /// Gets the refresh token.
+        /// </summary>
+        /// <value>
+        /// The refresh token.
+        /// </value>
+        public string RefreshToken { get; }
+    }
+}

--- a/test/UnitTests/Authentications/AuthenticateDelegatingHandlerTests.cs
+++ b/test/UnitTests/Authentications/AuthenticateDelegatingHandlerTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using Xunit;
+
+namespace IdentityModel.UnitTests
+{
+    public class AuthenticateDelegatingHandlerTests
+    {
+        [Fact]
+        public async Task The_401_response_that_causes_token_refresh_and_retry_should_be_disposed_to_unblock_socket()
+        {
+            // arrange
+            var authenticationCache = new InProcAuthenticationCache();
+            var indirectOutputOfHttpResponses = new StubHttpResponsesHandler();
+            var authenticateDelegatingHandler = new AuthenticateDelegatingHandler(authenticationCache, indirectOutputOfHttpResponses);
+
+            var apiClient = new HttpClient(authenticateDelegatingHandler);
+
+            // act
+            await apiClient.GetStringAsync("http://someapi/somecall");
+
+            // assert
+            indirectOutputOfHttpResponses.FirstAttempt401Response
+                .Disposed
+                .Should()
+                .BeTrue("Unauthorized response should be disposed to avoid socket blocking");
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(10, 25)]
+        public async Task Decorating_requests_with_tokens_should_work_in_parallel(int interactions, int requests)
+        {
+            // arrange
+            using (var appServer = new InProcHttpServer())
+            using (var ssoServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("https://demo.identityserver.io/connect/token", "client", "secret", ssoServer.CreateHandler()))
+            {
+                var accessToken = Fake.ReferenceToken();
+                ssoServer.Handle(async context =>
+                {
+                    await Task.Delay(10).ConfigureAwait(false); // NOTE: simulate network delay
+                    context.Response = context.RequestIndex > 1
+                        ? context.StatusCode((HttpStatusCode) 429) // NOTE: Too Many Requests
+                        : context.Json(TokenConvert.ToJson(accessToken));
+                });
+                appServer.Handle(context =>
+                {
+                    var authorized = string.Equals(accessToken, context.Request.Headers.Authorization.Parameter);
+                    context.Response = context.StatusCode(authorized ? HttpStatusCode.OK : HttpStatusCode.Unauthorized);
+                });
+
+                var authenticationCache = new AuthenticationCache(new ClientCredentialsProvider(tokenClient, "api"));
+                await Task.WhenAll(Enumerable.Range(0, interactions).Select(async i =>
+                {
+                    await Task.Delay(1).ConfigureAwait(false);
+                    using (var appClient = appServer.CreateClient(handler => new AuthenticateDelegatingHandler(authenticationCache, handler)))
+                    {
+                        await Task.WhenAll(Enumerable.Range(0, requests).Select(async j =>
+                        {
+                            // arrange
+                            await Task.Delay(1).ConfigureAwait(false);
+
+                            // act
+                            var response = await appClient.GetAsync("https://demo.identityserver.io/api/test");
+
+                            // assert
+                            response.EnsureSuccessStatusCode();
+
+                        })).ConfigureAwait(false);
+                    }
+                })).ConfigureAwait(false);
+            }
+        }
+
+        private sealed class InProcAuthenticationCache : IAuthenticationCache
+        {
+            public string TokenType { get; set; } = "InProc";
+            public string AccessToken { get; set; }
+            public string RefreshToken { get; set; }
+
+            public Task<bool> UpdateAsync(CancellationToken cancellationToken) => Task.FromResult(true);
+            public Task<bool> RotateAsync(string accessToken, CancellationToken cancellationToken) => Task.FromResult(true);
+        }
+    }
+}

--- a/test/UnitTests/Authentications/AuthenticationCacheTests.cs
+++ b/test/UnitTests/Authentications/AuthenticationCacheTests.cs
@@ -1,0 +1,341 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using Xunit;
+
+namespace IdentityModel.UnitTests
+{
+    public class AuthenticationCacheTests
+    {
+        [Fact]
+        public void Creating_should_not_throw()
+        {
+            // arrange
+            var authenticationProvider = new InProcAuthenticationProvider();
+
+            // act
+            Action act = () => new AuthenticationCache(authenticationProvider);
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_should_not_throw()
+        {
+            // arrange
+            var authenticationProvider = new InProcAuthenticationProvider();
+            var authenticationCache = new AuthenticationCache(authenticationProvider);
+
+            // act
+            Action act = () => authenticationCache.Dispose();
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void TokenType_should_be_Bearer_by_default()
+        {
+            // arrange
+            var authenticationProvider = new InProcAuthenticationProvider();
+
+            // act
+            var authenticationCache = new AuthenticationCache(authenticationProvider);
+
+            // assert
+            authenticationCache.TokenType.Should().Be("Bearer");
+        }
+
+        [Fact]
+        public void Access_token_should_be_reusable()
+        {
+            // arrange
+            var expectedAccessToken = Fake.ReferenceToken();
+
+            var authenticationProvider = new InProcAuthenticationProvider();
+
+            // act
+            var authenticationCache = new AuthenticationCache(authenticationProvider, accessToken: expectedAccessToken);
+
+            // assert
+            authenticationCache.AccessToken.Should().Be(expectedAccessToken, "The access token should be reusable.");
+        }
+
+        [Fact]
+        public void Refresh_token_should_be_reusable()
+        {
+            // arrange
+            var expectedRefreshToken = Fake.ReferenceToken();
+
+            var authenticationProvider = new InProcAuthenticationProvider();
+
+            // act
+            var authenticationCache = new AuthenticationCache(authenticationProvider, refreshToken: expectedRefreshToken);
+
+            // assert
+            authenticationCache.RefreshToken.Should().Be(expectedRefreshToken, "The refresh token should be reusable.");
+        }
+
+        [Fact]
+        public async Task Refresh_token_should_be_retained_if_token_response_contains_only_access_token()
+        {
+            // arrange
+            var oldAccessToken = Fake.ReferenceToken();
+            var oldRefreshToken = Fake.ReferenceToken();
+            var newAccessToken = Fake.ReferenceToken();
+
+            var authenticationProvider = new InProcAuthenticationProvider(
+                refreshToken: (_, ct) => Tuple.Create(newAccessToken, default(string))
+            );
+            var authenticationCache = new AuthenticationCache(authenticationProvider, oldRefreshToken, oldAccessToken);
+
+            // act
+            await authenticationCache.UpdateAsync().ConfigureAwait(false);
+
+            // assert
+            authenticationCache.AccessToken.Should().Be(newAccessToken);
+            authenticationCache.RefreshToken.Should().Be(oldRefreshToken, "Refresh token should be retained if token response contains only access token");
+        }
+
+        [Fact]
+        public async Task TokenReceived_should_be_raised_with_access_and_refresh_tokens()
+        {
+            // arrange
+            var expectedAccessToken = Fake.ReferenceToken();
+            var expectedRefreshToken = Fake.ReferenceToken();
+
+            var authenticationProvider = new InProcAuthenticationProvider(
+                acquireToken: _ => Tuple.Create(expectedAccessToken, expectedRefreshToken)
+            );
+            var authenticationCache = new AuthenticationCache(authenticationProvider);
+
+            // act
+            string accessToken = null, refreshToken = null;
+            authenticationCache.TokenReceived += (sender, args) =>
+            {
+                accessToken = args.AccessToken;
+                refreshToken = args.RefreshToken;
+            };
+            await authenticationCache.UpdateAsync().ConfigureAwait(false);
+
+            // assert
+            accessToken.Should().Be(expectedAccessToken);
+            refreshToken.Should().Be(expectedRefreshToken);
+        }
+
+        [Fact]
+        public async Task Update_should_request_tokens_depends_on_refresh_token()
+        {
+            string accessToken1 = Fake.ReferenceToken();
+            string accessToken2 = Fake.ReferenceToken(), refreshToken2 = Fake.ReferenceToken();
+            string accessToken3 = Fake.ReferenceToken(), refreshToken3 = Fake.ReferenceToken();
+
+            using (var httpServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("http://server/token", "client", httpServer.CreateHandler()))
+            {
+                httpServer.Handle(context =>
+                {
+                    if (context.RequestBody.Contains("client_id=client"))
+                    {
+                        switch (context.RequestIndex)
+                        {
+                            case 1:
+                            {
+                                if (context.RequestBody.Contains("grant_type=client_credentials"))
+                                {
+                                    context.Response = context.Json(TokenConvert.ToJson(accessToken1));
+                                }
+                                break;
+                            }
+                            case 2:
+                            {
+                                if (context.RequestBody.Contains("grant_type=client_credentials"))
+                                {
+                                    context.Response = context.Json(TokenConvert.ToJson(accessToken2, refreshToken2));
+                                }
+                                break;
+                            }
+                            case 3:
+                            {
+                                if (context.RequestBody.Contains("grant_type=refresh_token") &&
+                                    context.RequestBody.Contains($"refresh_token={refreshToken2}"))
+                                {
+                                    context.Response = context.Json(TokenConvert.ToJson(accessToken3, refreshToken3));
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    context.Response = context.Response ?? context.StatusCode(HttpStatusCode.BadRequest);
+                });
+
+                // arrange
+                var authenticationCache = new AuthenticationCache(new ClientCredentialsProvider(tokenClient));
+
+                // act
+                await authenticationCache.UpdateAsync().ConfigureAwait(false);
+
+                // assert
+                authenticationCache.AccessToken.Should().Be(accessToken1);
+                authenticationCache.RefreshToken.Should().BeNull();
+
+                // act
+                await authenticationCache.UpdateAsync().ConfigureAwait(false);
+
+                // assert
+                authenticationCache.AccessToken.Should().Be(accessToken2);
+                authenticationCache.RefreshToken.Should().Be(refreshToken2);
+
+                // act
+                await authenticationCache.UpdateAsync().ConfigureAwait(false);
+
+                // assert
+                authenticationCache.AccessToken.Should().Be(accessToken3);
+                authenticationCache.RefreshToken.Should().Be(refreshToken3);
+            }
+        }
+
+        [Fact]
+        public async Task Rotate_should_do_nothing_if_access_tokens_are_not_equal()
+        {
+            // arrange
+            var accessToken1 = Fake.ReferenceToken();
+            var accessToken2 = Fake.ReferenceToken();
+
+            var authenticationCache = new AuthenticationCache(new InProcAuthenticationProvider(), accessToken: accessToken2);
+
+            // act
+            var actual = await authenticationCache.RotateAsync(accessToken1).ConfigureAwait(false);
+
+            // assert
+            actual.Should().BeTrue("Access token should be retained if rotating access token differs.");
+            authenticationCache.AccessToken.Should().Be(accessToken2);
+        }
+
+        [Fact]
+        public async Task Rotate_should_do_nothing_if_timeout()
+        {
+            // arrange
+            var countdown = new CountdownEvent(10);
+            var authenticationProvider = new InProcAuthenticationProvider(acquireToken: _ =>
+            {
+                countdown.Wait(TimeSpan.FromSeconds(1));
+                return Tuple.Create(Fake.ReferenceToken(), default(string));
+            });
+            var authenticationCache = new AuthenticationCache(authenticationProvider)
+            {
+                Timeout = TimeSpan.FromMilliseconds(1)
+            };
+
+            var accessToken = authenticationCache.AccessToken;
+
+            // act
+            var results = await Task.WhenAll(
+                Enumerable.Range(0, countdown.InitialCount).Select(async _ =>
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(false);
+                    var task = authenticationCache.RotateAsync(accessToken);
+                    Task.Delay(TimeSpan.FromMilliseconds(25)).ContinueWith(x => countdown.Signal());
+                    return await task.ConfigureAwait(false);
+                })
+            ).ConfigureAwait(false);
+
+            // assert
+            results.Count(_ => _).Should().Be(1, "Only 1 operation succeeded, the rest skipped by timeout.");
+        }
+
+        [Fact]
+        public async Task Rotate_should_update_tokens_if_access_tokens_are_equal()
+        {
+            // arrange
+            var accessToken1 = Fake.ReferenceToken();
+            var accessToken2 = Fake.ReferenceToken();
+
+            var authenticationProvider = new InProcAuthenticationProvider(
+                acquireToken: _ => Tuple.Create(accessToken2, default(string))
+            );
+            var authenticationCache = new AuthenticationCache(authenticationProvider, accessToken: accessToken1);
+
+            // act
+            var actual = await authenticationCache.RotateAsync(accessToken1).ConfigureAwait(false);
+
+            // assert
+            actual.Should().BeTrue("Access token should be rotated if access tokens are equal.");
+            authenticationCache.AccessToken.Should().Be(accessToken2);
+        }
+
+        [Fact]
+        public async Task Rotate_should_update_tokens_only_once_during_the_same_rotation()
+        {
+            // arrange
+            var accessToken = Fake.ReferenceToken();
+            var refreshToken = Fake.ReferenceToken();
+
+            var authenticationProvider = new InProcAuthenticationProvider(refreshToken: (token, _) =>
+            {
+                if (token == refreshToken)
+                {
+                    return Tuple.Create(Fake.ReferenceToken(), Fake.ReferenceToken());
+                }
+                throw new NotSupportedException("Access token should be requested once.");
+            });
+            var authenticationCache = new AuthenticationCache(authenticationProvider, refreshToken, accessToken);
+
+            // act
+            var results = await Task.WhenAll(
+                Enumerable.Range(0, 10).Select(async _ =>
+                {
+                    await Task.Delay(1).ConfigureAwait(false);
+                    return await authenticationCache.RotateAsync(accessToken).ConfigureAwait(false);
+                })
+            ).ConfigureAwait(false);
+
+            // assert
+            results.Should().AllBeEquivalentTo(true);
+        }
+
+        private sealed class InProcAuthenticationProvider : IAuthenticationProvider
+        {
+            private readonly Func<CancellationToken, Tuple<string, string>> _acquireToken;
+            private readonly Func<string, CancellationToken, Tuple<string, string>> _refreshToken;
+
+            public InProcAuthenticationProvider(
+                Func<CancellationToken, Tuple<string, string>> acquireToken = null,
+                Func<string, CancellationToken, Tuple<string, string>> refreshToken = null)
+            {
+                _acquireToken = acquireToken;
+                _refreshToken = refreshToken;
+            }
+
+            public async Task<TokenResponse> RequestTokenAsync(CancellationToken cancellationToken)
+            {
+                if (_acquireToken == null)
+                {
+                    return new TokenResponse(new NotSupportedException());
+                }
+
+                var (newAccessToken, newRefreshToken) = _acquireToken.Invoke(cancellationToken);
+                return TokenConvert.ToTokenResponse(newAccessToken, newRefreshToken);
+            }
+
+            public async Task<TokenResponse> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken)
+            {
+                if (_refreshToken == null)
+                {
+                    return new TokenResponse(new NotSupportedException());
+                }
+
+                var (newAccessToken, newRefreshToken) = _refreshToken.Invoke(refreshToken, cancellationToken);
+                return TokenConvert.ToTokenResponse(newAccessToken, newRefreshToken);
+            }
+        }
+    }
+}

--- a/test/UnitTests/Authentications/AuthorizationCodeProviderTests.cs
+++ b/test/UnitTests/Authentications/AuthorizationCodeProviderTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using Xunit;
+
+namespace IdentityModel.UnitTests
+{
+    public class AuthorizationCodeProviderTests
+    {
+        [Fact]
+        public void Creating_with_token_client_should_not_throw()
+        {
+            // arrange
+            var tokenClient = new TokenClient("http://server/token", "client");
+
+            // act
+            Action act = () => new AuthorizationCodeProvider(tokenClient, "code", "redirectUrl");
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Creating_should_not_throw()
+        {
+            // act
+            Action act = () => new AuthorizationCodeProvider("http://server/token", "client", "secret", "code", "redirectUrl");
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_should_not_throw()
+        {
+            // arrange
+            var authorizationCodeProvider = new AuthorizationCodeProvider("http://server/token", "client", "secret", "code", "redirectUrl");
+
+            // act
+            Action act = () => authorizationCodeProvider.Dispose();
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public async Task Should_request_tokens()
+        {
+            using (var ssoServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("https://demo.identityserver.io/connect/token", "client", "secret", ssoServer.CreateHandler()))
+            {
+                // arrange
+                var code = Fake.String();
+                var redirectUri = Fake.String();
+                var expectedAccessToken = Fake.ReferenceToken();
+                var expectedRefreshToken = Fake.ReferenceToken();
+
+                ssoServer.Handle(context =>
+                {
+                    if (context.RequestBody.Contains("grant_type=authorization_code") &&
+                        context.RequestBody.Contains($"code={code}") &&
+                        context.RequestBody.Contains($"redirect_uri={redirectUri}"))
+                    {
+                        context.Response = context.Json(TokenConvert.ToJson(expectedAccessToken, expectedRefreshToken));
+                    }
+                });
+
+                var authorizationCodeProvider = new AuthorizationCodeProvider(tokenClient, code, redirectUri);
+
+                // act
+                var tokenResponse = await authorizationCodeProvider.RequestTokenAsync().ConfigureAwait(false);
+
+                // assert
+                tokenResponse.Should().NotBeNull();
+                tokenResponse.AccessToken.Should().Be(expectedAccessToken);
+                tokenResponse.RefreshToken.Should().Be(expectedRefreshToken);
+            }
+        }
+
+        [Fact]
+        public async Task Should_refresh_tokens()
+        {
+            using (var ssoServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("https://demo.identityserver.io/connect/token", "client", "secret", ssoServer.CreateHandler()))
+            {
+                // arrange
+                var refreshToken = Fake.ReferenceToken();
+                var expectedAccessToken = Fake.ReferenceToken();
+                var expectedRefreshToken = Fake.ReferenceToken();
+
+                ssoServer.Handle(context =>
+                {
+                    if (context.RequestBody.Contains("grant_type=refresh_token") &&
+                        context.RequestBody.Contains($"refresh_token={refreshToken}"))
+                    {
+                        context.Response = context.Json(TokenConvert.ToJson(expectedAccessToken, expectedRefreshToken));
+                    }
+                });
+
+                var authorizationCodeProvider = new AuthorizationCodeProvider(tokenClient, Fake.String(), Fake.String());
+
+                // act
+                var tokenResponse = await authorizationCodeProvider.RefreshTokenAsync(refreshToken).ConfigureAwait(false);
+
+                // assert
+                tokenResponse.Should().NotBeNull();
+                tokenResponse.AccessToken.Should().Be(expectedAccessToken);
+                tokenResponse.RefreshToken.Should().Be(expectedRefreshToken);
+            }
+        }
+    }
+}

--- a/test/UnitTests/Authentications/ClientCredentialsProviderTests.cs
+++ b/test/UnitTests/Authentications/ClientCredentialsProviderTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using Xunit;
+
+namespace IdentityModel.UnitTests
+{
+    public class ClientCredentialsProviderTests
+    {
+        [Fact]
+        public void Creating_with_token_client_should_not_throw()
+        {
+            // arrange
+            var tokenClient = new TokenClient("http://server/token", "client");
+
+            // act
+            Action act = () => new ClientCredentialsProvider(tokenClient, "scope");
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Creating_should_not_throw()
+        {
+            // act
+            Action act = () => new ClientCredentialsProvider("http://server/token", "client", "secret", "scope");
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_should_not_throw()
+        {
+            // arrange
+            var clientCredentialsProvider = new ClientCredentialsProvider("http://server/token", "client", "secret", "scope");
+
+            // act
+            Action act = () => clientCredentialsProvider.Dispose();
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public async Task Should_request_tokens()
+        {
+            using (var ssoServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("https://demo.identityserver.io/connect/token", "client", "secret", ssoServer.CreateHandler()))
+            {
+                // arrange
+                var scope = Fake.String();
+                var expectedAccessToken = Fake.ReferenceToken();
+                var expectedRefreshToken = Fake.ReferenceToken();
+
+                ssoServer.Handle(context =>
+                {
+                    if (context.RequestBody.Contains("grant_type=client_credentials") &&
+                        context.RequestBody.Contains($"scope={scope}"))
+                    {
+                        context.Response = context.Json(TokenConvert.ToJson(expectedAccessToken, expectedRefreshToken));
+                    }
+                });
+
+                var clientCredentialsProvider = new ClientCredentialsProvider(tokenClient, scope);
+
+                // act
+                var tokenResponse = await clientCredentialsProvider.RequestTokenAsync().ConfigureAwait(false);
+
+                // assert
+                tokenResponse.Should().NotBeNull();
+                tokenResponse.AccessToken.Should().Be(expectedAccessToken);
+                tokenResponse.RefreshToken.Should().Be(expectedRefreshToken);
+            }
+        }
+
+        [Fact]
+        public async Task Should_refresh_tokens()
+        {
+            using (var ssoServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("https://demo.identityserver.io/connect/token", "client", "secret", ssoServer.CreateHandler()))
+            {
+                var scope = Fake.String();
+                var refreshToken = Fake.ReferenceToken();
+                var expectedAccessToken = Fake.ReferenceToken();
+                var expectedRefreshToken = Fake.ReferenceToken();
+
+                ssoServer.Handle(context =>
+                {
+                    if (context.RequestBody.Contains("grant_type=refresh_token") &&
+                        context.RequestBody.Contains($"refresh_token={refreshToken}"))
+                    {
+                        context.Response = context.Json(TokenConvert.ToJson(expectedAccessToken, expectedRefreshToken));
+                    }
+                });
+
+                // arrange
+                var clientCredentialsProvider = new ClientCredentialsProvider(tokenClient, scope);
+
+                // act
+                var tokenResponse = await clientCredentialsProvider.RefreshTokenAsync(refreshToken).ConfigureAwait(false);
+
+                // assert
+                tokenResponse.Should().NotBeNull();
+                tokenResponse.AccessToken.Should().Be(expectedAccessToken);
+                tokenResponse.RefreshToken.Should().Be(expectedRefreshToken);
+            }
+        }
+    }
+}

--- a/test/UnitTests/Authentications/ResourceOwnerPasswordProviderTests.cs
+++ b/test/UnitTests/Authentications/ResourceOwnerPasswordProviderTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel.Client;
+using Xunit;
+
+namespace IdentityModel.UnitTests
+{
+    public class ResourceOwnerPasswordProviderTests
+    {
+        [Fact]
+        public void Creating_with_token_client_should_not_throw()
+        {
+            // arrange
+            var tokenClient = new TokenClient("http://server/token", "client");
+
+            // act
+            Action act = () => new ResourceOwnerPasswordProvider(tokenClient, "username", "password", "scope");
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Creating_should_not_throw()
+        {
+            // act
+            Action act = () => new ResourceOwnerPasswordProvider("http://server/token", "client", "secret","username", "password", "scope");
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Dispose_should_not_throw()
+        {
+            // arrange
+            var resourceOwnerPasswordProvider = new ResourceOwnerPasswordProvider("http://server/token", "client", "secret","username", "password", "scope");
+
+            // act
+            Action act = () => resourceOwnerPasswordProvider.Dispose();
+
+            // assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public async Task Should_request_tokens()
+        {
+            using (var ssoServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("https://demo.identityserver.io/connect/token", "client", "secret", ssoServer.CreateHandler()))
+            {
+                // arrange
+                var userName = Fake.String();
+                var password = Fake.String();
+                var expectedAccessToken = Fake.ReferenceToken();
+                var expectedRefreshToken = Fake.ReferenceToken();
+
+                ssoServer.Handle(context =>
+                {
+                    if (context.RequestBody.Contains("grant_type=password") &&
+                        context.RequestBody.Contains($"username={userName}") &&
+                        context.RequestBody.Contains($"password={password}"))
+                    {
+                        context.Response = context.Json(TokenConvert.ToJson(expectedAccessToken, expectedRefreshToken));
+                    }
+                });
+
+                var resourceOwnerPasswordProvider = new ResourceOwnerPasswordProvider(tokenClient, userName, password);
+
+                // act
+                var tokenResponse = await resourceOwnerPasswordProvider.RequestTokenAsync().ConfigureAwait(false);
+
+                // assert
+                tokenResponse.Should().NotBeNull();
+                tokenResponse.AccessToken.Should().Be(expectedAccessToken);
+                tokenResponse.RefreshToken.Should().Be(expectedRefreshToken);
+            }
+        }
+
+        [Fact]
+        public async Task Should_refresh_tokens()
+        {
+            using (var ssoServer = new InProcHttpServer())
+            using (var tokenClient = new TokenClient("https://demo.identityserver.io/connect/token", "client", "secret", ssoServer.CreateHandler()))
+            {
+                // arrange
+                var refreshToken = Fake.ReferenceToken();
+                var expectedAccessToken = Fake.ReferenceToken();
+                var expectedRefreshToken = Fake.ReferenceToken();
+
+                ssoServer.Handle(context =>
+                {
+                    if (context.RequestBody.Contains("grant_type=refresh_token") &&
+                        context.RequestBody.Contains($"refresh_token={refreshToken}"))
+                    {
+                        context.Response = context.Json(TokenConvert.ToJson(expectedAccessToken, expectedRefreshToken));
+                    }
+                });
+
+                var resourceOwnerPasswordProvider = new ResourceOwnerPasswordProvider(tokenClient, Fake.String(), Fake.String());
+
+                // act
+                var tokenResponse = await resourceOwnerPasswordProvider.RefreshTokenAsync(refreshToken).ConfigureAwait(false);
+
+                // assert
+                tokenResponse.Should().NotBeNull();
+                tokenResponse.AccessToken.Should().Be(expectedAccessToken);
+                tokenResponse.RefreshToken.Should().Be(expectedRefreshToken);
+            }
+        }
+    }
+}

--- a/test/UnitTests/Utils/Fake.cs
+++ b/test/UnitTests/Utils/Fake.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+
+namespace IdentityModel.UnitTests
+{
+    internal static class Fake
+    {
+        public static string ReferenceToken()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+
+        public static string String()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+}

--- a/test/UnitTests/Utils/InProcHttpServer.cs
+++ b/test/UnitTests/Utils/InProcHttpServer.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdentityModel.UnitTests
+{
+    internal sealed class InProcHttpServer : IDisposable
+    {
+        public sealed class HttpContext
+        {
+            public HttpContext(HttpRequestMessage request, int requestIndex, string requestBody, CancellationToken cancellationToken)
+            {
+                Request = request ?? throw new ArgumentNullException(nameof(request));
+                RequestIndex = requestIndex;
+                RequestBody = requestBody ?? string.Empty;
+                CancellationToken = cancellationToken;
+            }
+
+            public CancellationToken CancellationToken { get; }
+            public HttpRequestMessage Request { get; }
+            public int RequestIndex { get; }
+            public string RequestBody { get; }
+            public HttpResponseMessage Response { get; set; }
+
+            public HttpResponseMessage Json(string json)
+            {
+                var response = StatusCode(HttpStatusCode.OK);
+                response.Content = new StringContent(json, Encoding.UTF8, "application/json");
+                return response;
+            }
+
+            public HttpResponseMessage StatusCode(HttpStatusCode httpStatusCode)
+            {
+                return new HttpResponseMessage(httpStatusCode)
+                {
+                    RequestMessage = Request
+                };
+            }
+        }
+
+        private readonly List<Func<HttpContext, Task>> _handlers = new List<Func<HttpContext, Task>>();
+        private int _requestIndex;
+
+        public void Dispose()
+        {
+            _handlers.Clear();
+        }
+
+        public InProcHttpServer Handle(Action<HttpContext> handler)
+        {
+            return Handle(context =>
+            {
+                handler?.Invoke(context);
+                return Task.FromResult(true);
+            });
+        }
+
+        public InProcHttpServer Handle(Func<HttpContext, Task> handler)
+        {
+            _handlers.Add(handler ?? throw new ArgumentNullException(nameof(handler)));
+            return this;
+        }
+
+        public HttpClient CreateClient(Func<HttpMessageHandler, HttpMessageHandler> decorate = null)
+        {
+            var handler = CreateHandler();
+            if (decorate != null)
+            {
+                handler = decorate(handler);
+            }
+            return new HttpClient(handler);
+        }
+
+        public HttpMessageHandler CreateHandler()
+        {
+            return new InProcHttpMessageHandler(this);
+        }
+
+        private async Task<HttpResponseMessage> ServeAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var requestIndex = Interlocked.Increment(ref _requestIndex);
+            var requestBody = request.Content != null
+                ? await request.Content.ReadAsStringAsync().ConfigureAwait(false)
+                : string.Empty;
+            var httpContext = new HttpContext(request, requestIndex, requestBody, cancellationToken);
+            try
+            {
+                foreach (var handler in _handlers)
+                {
+                    await handler.Invoke(httpContext).ConfigureAwait(false);
+                    if (httpContext.Response != null)
+                    {
+                        return httpContext.Response;
+                    }
+                }
+            }
+            catch
+            {
+                return httpContext.StatusCode(HttpStatusCode.InternalServerError);
+            }
+            return httpContext.StatusCode(HttpStatusCode.NotAcceptable);
+        }
+
+        private sealed class InProcHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly InProcHttpServer _server;
+
+            public InProcHttpMessageHandler(InProcHttpServer server)
+            {
+                _server = server ?? throw new ArgumentNullException(nameof(server));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return _server.ServeAsync(request, cancellationToken);
+            }
+        }
+    }
+}

--- a/test/UnitTests/Utils/TokenConvert.cs
+++ b/test/UnitTests/Utils/TokenConvert.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using IdentityModel.Client;
+
+namespace IdentityModel.UnitTests
+{
+    internal static class TokenConvert
+    {
+        public static TokenResponse ToTokenResponse(string accessToken, string refreshToken)
+        {
+            return new TokenResponse(ToJson(accessToken, refreshToken));
+        }
+
+        public static string ToJson(string accessToken, string refreshToken = null)
+        {
+            if (accessToken == null) throw new ArgumentNullException(nameof(accessToken));
+            if (refreshToken == null)
+            {
+                return $"{{\"access_token\":\"{accessToken}\"}}";
+            }
+            return $"{{\"access_token\":\"{accessToken}\",\"refresh_token\":\"{refreshToken}\"}}";
+        }
+    }
+}


### PR DESCRIPTION
**Purpose:**

* Share Access and Refresh Tokens between HttpClients to be more friendly with HttpClienFactory
* It also solves the #126 issue

**Glossary:**

* `AuthenticationCache` is responsible to keep the tokens and rotate them on request
* `AuthenticateDelegatingHandler` is an adapter for the `HttpClient` to populate the authentication header from the `AuthenticationCache` during the request. It could be managed easily by the `HttpClientFactory`.
* `IAuthenticationProvider` is an abstraction on how to get new tokens for the `AuthenticationCache`.
* `ClientCredentialsProvider`, `AuthorizationCodeProvider` and `ResourceOwnerPasswordProvider` are the real implementations of the auth flow.

**Example:**

```csharp
internal static class IdentityModelClientExtensions
{
	public static IServiceCollection AddDemoIdentityServerClient(this IServiceCollection services, Uri address, IAuthenticationProvider authenticationProvider, bool sharedAuthenticationCache = true)
	{
		if (sharedAuthenticationCache)
		{
			services
				.AddHttpClientAuthentication(sp => authenticationProvider)
				.AddHttpClient<DemoIdentityServerClient>(client => client.BaseAddress = address)
				.AddAuthenticationHandler();
		}
		else
		{
			var authenticationCache = new AuthenticationCache(authenticationProvider);
			services
				.AddHttpClient<DemoIdentityServerClient>(client => client.BaseAddress = address)
				.AddAuthenticationHandler(sp => authenticationCache);
		}
		return services;
	}

	public static IServiceCollection AddHttpClientAuthentication(this IServiceCollection services, Func<IServiceProvider, IAuthenticationProvider> authenticationProviderResolver)
	{
		services.TryAddSingleton<IAuthenticationProvider>(authenticationProviderResolver);
		services.TryAddSingleton<IAuthenticationCache, AuthenticationCache>();
		services.TryAddTransient<AuthenticateDelegatingHandler>();
		return services;
	}

	public static IHttpClientBuilder AddAuthenticationHandler(this IHttpClientBuilder builder)
	{
		if (builder == null) throw new ArgumentNullException(nameof (builder));
		builder.AddHttpMessageHandler<AuthenticateDelegatingHandler>();
		return builder;
	}

	public static IHttpClientBuilder AddAuthenticationHandler(this IHttpClientBuilder builder, Func<IServiceProvider, IAuthenticationCache> authenticationCacheResolver)
	{
		if (builder == null) throw new ArgumentNullException(nameof (builder));
		builder.AddHttpMessageHandler(sp => new AuthenticateDelegatingHandler(authenticationCacheResolver.Invoke(sp)));
		return builder;
	}
}
```