### PR TITLE
update SimpleExec to 6.0.0-beta.1

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="2.3.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.3" />
-    <PackageReference Include="SimpleExec" Version="5.0.1" />
+    <PackageReference Include="SimpleExec" Version="6.0.0-beta.1" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Some overlap with #217 and #218 but this updates SimpleExec *only*, without trying to update the build image at the same time.