### PR TITLE
StringExtension fix - changing Base64 to Base64Url 

### DIFF
--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -27,7 +27,7 @@ namespace IdentityModel
                 var bytes = Encoding.UTF8.GetBytes(input);
                 var hash = sha.ComputeHash(bytes);
 
-                return Convert.ToBase64String(hash);
+                return Base64Url.Encode(hash);
             }
         }
 
@@ -45,7 +45,7 @@ namespace IdentityModel
                 var bytes = Encoding.UTF8.GetBytes(input);
                 var hash = sha.ComputeHash(bytes);
 
-                return Convert.ToBase64String(hash);
+                return Base64Url.Encode(hash);
             }
         }
     }


### PR DESCRIPTION
Proposed change is to follow the RFC 7636 (OAuth with PKCE ) for code_challange requirements, where the hashed code_verifier should be Base64Url encoded (instead of standard Base64).