### PR TITLE
integrate build CLI with Bullseye

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.1.0" />
+    <PackageReference Include="Bullseye" Version="3.2.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.1" />
     <PackageReference Include="SimpleExec" Version="6.2.0" />
   </ItemGroup>


### PR DESCRIPTION
By integrating Bullseye with McMaster (using new API's from Bullseye 3.2.0), you get proper help from you build script, including your custom option (`--sign`) and all the Bullseye options:

![image](https://user-images.githubusercontent.com/677704/71363107-f2aa0080-258f-11ea-925e-6e79dbd593ba.png)
