### PR TITLE
ignore empty query string entries in AuthorizeResponse urls

### DIFF
--- a/src/Client/Messages/AuthorizeResponse.cs
+++ b/src/Client/Messages/AuthorizeResponse.cs
@@ -154,7 +154,7 @@ namespace IdentityModel.Client
                 fragments = new[] { "", Raw };
             }
 
-            var qparams = fragments[1].Split('&');
+            var qparams = fragments[1].Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var param in qparams)
             {

--- a/test/UnitTests/AuthorizeResponseTests.cs
+++ b/test/UnitTests/AuthorizeResponseTests.cs
@@ -85,6 +85,20 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
+        public void AccessToken_Response_with_QueryString_and_Empty_Entry()
+        {
+            var url = "http://server/callback?access_token=foo&&sid=123&";
+
+            var response = new AuthorizeResponse(url);
+
+            response.IsError.Should().BeFalse();
+            response.AccessToken.Should().Be("foo");
+
+            response.Values["sid"].Should().Be("123");
+            response.TryGet("sid").Should().Be("123");
+        }
+
+        [Fact]
         public void form_post_format_should_parse()
         {
             var form = "id_token=foo&code=bar&scope=baz&session_state=quux";


### PR DESCRIPTION
Fix for https://github.com/IdentityModel/IdentityModel/issues/288