### PR TITLE
simplify build script by using a target to sign instead of an option

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="3.3.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
     <PackageReference Include="SimpleExec" Version="6.2.0" />
   </ItemGroup>
   


### PR DESCRIPTION
- Removes the dependency on `McMaster.Extensions.CommandLineUtils`
- Reverts to simple Bullseye usage (`args` passthrough)

To run a signed build: `build.ps1 sign` (instead of `build.ps1 --sign`).