### PR TITLE
remove partial clean in build script and revert to default output path for artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
     displayName: 'Push package to Github'
     inputs:
       command: push
-      packagesToPush: 'artifacts/*.nupkg'
+      packagesToPush: 'src/bin/Release/*.nupkg'
       nuGetFeedType: external
       publishFeedCredentials: 'GitHub Packages'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -20,8 +20,6 @@ namespace build
 
         internal static void Main(string[] args)
         {
-            CleanArtifacts();
-
             Target(Targets.Build, () =>
             {
                 Run("dotnet", "build -c Release");
@@ -29,7 +27,7 @@ namespace build
 
             Target(Targets.SignBinary, DependsOn(Targets.Build), () =>
             {
-                Sign("./src/bin/release", "IdentityModel.dll");
+                Sign("./src/bin/Release", "IdentityModel.dll");
             });
 
             Target(Targets.Test, DependsOn(Targets.Build), () =>
@@ -39,12 +37,12 @@ namespace build
 
             Target(Targets.Pack, DependsOn(Targets.Build), () =>
             {
-                Run("dotnet", "pack ./src/IdentityModel.csproj -c Release -o ./artifacts --no-build");
+                Run("dotnet", "pack ./src/IdentityModel.csproj -c Release --no-build");
             });
 
             Target(Targets.SignPackage, DependsOn(Targets.Pack), () =>
             {
-                Sign("./artifacts", "*.nupkg");
+                Sign("./src/bin/Release", "*.nupkg");
             });
 
             Target("default", DependsOn(Targets.Test, Targets.Pack));
@@ -73,14 +71,6 @@ namespace build
             {
                 Console.WriteLine($"  Signing {file}");
                 Run("dotnet", $"SignClient sign -c {signClientConfig} -i {file} -r sc-ids@dotnetfoundation.org -s \"{signClientSecret}\" -n 'IdentityServer4'", noEcho: true);
-            }
-        }
-
-        private static void CleanArtifacts()
-        {
-            foreach (var file in Directory.CreateDirectory("./artifacts").GetFiles())
-            {
-                file.Delete();
             }
         }
     }


### PR DESCRIPTION
- `CleanArtifacts` was called when running, for example, `build.cmd --help`, which doesn't seem right.
- `CleanArtifacts` was only ever performing a partial clean, since the output of the `pack` target is only part of the artifacts produced by the build. For example, the `build` target produces a bunch of stuff in `src/bin` and `src/obj`. To run a full clean, it would be better to run `git clean -xdf` on demand.
- The custom output path for `pack` isn't really required.