### PR TITLE
suppress dotnet logo in build script

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -36,7 +36,7 @@ namespace build
 
             Target(Targets.Build, DependsOn(Targets.CleanBuildOutput), () =>
             {
-                Run("dotnet", "build -c Release");
+                Run("dotnet", "build -c Release --nologo");
             });
 
             Target(Targets.SignBinary, DependsOn(Targets.Build, Targets.RestoreTools), () =>
@@ -46,7 +46,7 @@ namespace build
 
             Target(Targets.Test, DependsOn(Targets.Build), () =>
             {
-                Run("dotnet", "test -c Release --no-build");
+                Run("dotnet", "test -c Release --no-build --nologo");
             });
 
             Target(Targets.CleanPackOutput, () =>


### PR DESCRIPTION
This is the last thing I spotted.

After this I believe it's ready to propagate to the other repos.