### PR TITLE
Corrected inline documentation for TokenExchangeTokenRequest

### DIFF
--- a/src/Client/Messages/TokenRequest.cs
+++ b/src/Client/Messages/TokenRequest.cs
@@ -134,7 +134,7 @@ namespace IdentityModel.Client
     }
     
     /// <summary>
-    /// Request for token using refresh_token
+    /// Request for token using urn:ietf:params:oauth:grant-type:token-exchange
     /// </summary>
     /// <seealso cref="TokenRequest" />
     public class TokenExchangeTokenRequest : TokenRequest


### PR DESCRIPTION
A slight copy-paste error was likely made in https://github.com/IdentityModel/IdentityModel/commit/28351436fd3dd2fde41e80816a787d43a4dde39d - this PR fixes the documentation