### PR TITLE
Add ResponseErrorType.MissingContent and add check for TokenResponses…

### DIFF
--- a/src/Client/Messages/ProtocolResponse.cs
+++ b/src/Client/Messages/ProtocolResponse.cs
@@ -76,6 +76,13 @@ namespace IdentityModel.Client
                 response.Exception = ex;
             }
 
+            if (!content.IsPresent()
+                && typeof(T) == typeof(TokenResponse))
+            {
+                response.ErrorType = ResponseErrorType.MissingContent;
+                response.ErrorMessage = "Missing Http content";
+            }
+
             await response.InitializeAsync(initializationData).ConfigureAwait();
             return response;
         }

--- a/src/Client/Messages/ResponseErrorType.cs
+++ b/src/Client/Messages/ResponseErrorType.cs
@@ -31,6 +31,11 @@ namespace IdentityModel.Client
         /// <summary>
         /// A policy violation - a configured policy was violated.
         /// </summary>
-        PolicyViolation
+        PolicyViolation,
+
+        /// <summary>
+        /// There was no content returned in the HTTP response
+        /// </summary>
+        MissingContent
     }
 }

--- a/test/UnitTests/HttpClientExtensions/HttpClientTokenRequestExtensionsResponseTests.cs
+++ b/test/UnitTests/HttpClientExtensions/HttpClientTokenRequestExtensionsResponseTests.cs
@@ -167,5 +167,17 @@ namespace IdentityModel.UnitTests
             response.Json.TryGetString("foo").Should().Be("foo");
             response.Json.TryGetString("bar").Should().Be("bar");
         }
+
+        [Fact]
+        public async Task Empty_token_response_should_be_handled_correctly()
+        {
+            var emptyHttpResponse = new HttpResponseMessage();
+            // It defaults to HttpStatusCode.OK
+            emptyHttpResponse.IsSuccessStatusCode.Should().BeTrue();
+            var tokenResponse = await ProtocolResponse.FromHttpResponseAsync<TokenResponse>(emptyHttpResponse);
+            tokenResponse.IsError.Should().BeTrue();
+            tokenResponse.ErrorType.Should().Be(ResponseErrorType.MissingContent);
+            tokenResponse.Error.Should().Be("Missing Http content");
+        }
     }
 }


### PR DESCRIPTION
… to have content

I've actually found that in a unit test while updating to the latest version. As far as I know, a `TokenResponse` always requires a request body to be present.