### PR TITLE
WIP Fix/363- Expose AuthTime

### DIFF
--- a/src/Client/Messages/TokenResponse.cs
+++ b/src/Client/Messages/TokenResponse.cs
@@ -71,7 +71,8 @@ namespace IdentityModel.Client
         /// <value>
         /// The expires in.
         /// </value>
-        public int ExpiresIn
+        /// <remarks>JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time.</remarks>
+        public long ExpiresIn
         {
             get
             {
@@ -79,7 +80,7 @@ namespace IdentityModel.Client
 
                 if (value != null)
                 {
-                    if (int.TryParse(value, out var theValue))
+                    if (long.TryParse(value, out var theValue))
                     {
                         return theValue;
                     }

--- a/src/Client/Messages/TokenResponse.cs
+++ b/src/Client/Messages/TokenResponse.cs
@@ -89,5 +89,30 @@ namespace IdentityModel.Client
                 return 0;
             }
         }
+
+        /// <summary>
+        /// Gets the authentication time.
+        /// </summary>
+        /// <value>
+        /// The auth time.
+        /// </value>
+        /// <remarks>JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time.</remarks>
+        public long AuthTime
+        {
+            get
+            {
+                var value = TryGet(OidcConstants.TokenResponse.AuthTime);
+
+                if (value != null)
+                {
+                    if (long.TryParse(value, out var theValue))
+                    {
+                        return theValue;
+                    }
+                }
+
+                return 0;
+            }
+        }
     }
 }

--- a/src/Client/Messages/TokenResponse.cs
+++ b/src/Client/Messages/TokenResponse.cs
@@ -97,7 +97,7 @@ namespace IdentityModel.Client
         /// The auth time.
         /// </value>
         /// <remarks>JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time.</remarks>
-        public long AuthTime
+        public long? AuthTime
         {
             get
             {
@@ -111,7 +111,7 @@ namespace IdentityModel.Client
                     }
                 }
 
-                return 0;
+                return null;
             }
         }
     }

--- a/src/OidcConstants.cs
+++ b/src/OidcConstants.cs
@@ -152,6 +152,7 @@ namespace IdentityModel
             public const string BearerTokenType = "Bearer";
             public const string IssuedTokenType = "issued_token_type";
             public const string Scope = "scope";
+            public const string AuthTime = "auth_time";
         }
 
         public static class TokenIntrospectionRequest

--- a/test/UnitTests/HttpClientExtensions/HttpClientTokenRequestExtensionsResponseTests.cs
+++ b/test/UnitTests/HttpClientExtensions/HttpClientTokenRequestExtensionsResponseTests.cs
@@ -34,7 +34,7 @@ namespace IdentityModel.UnitTests
             response.IsError.Should().BeFalse();
             response.ErrorType.Should().Be(ResponseErrorType.None);
             response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
-            response.ExpiresIn.Should().Be(3600);
+            response.ExpiresIn.Should().Be(16078989860);
             response.AccessToken.Should().Be("access_token");
             response.RefreshToken.Should().Be("refresh_token");
             response.TryGet("custom").Should().Be("custom");

--- a/test/UnitTests/HttpClientExtensions/HttpClientTokenRequestExtensionsResponseTests.cs
+++ b/test/UnitTests/HttpClientExtensions/HttpClientTokenRequestExtensionsResponseTests.cs
@@ -35,6 +35,7 @@ namespace IdentityModel.UnitTests
             response.ErrorType.Should().Be(ResponseErrorType.None);
             response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
             response.ExpiresIn.Should().Be(16078989860);
+            response.AuthTime.Should().Be(1607898926);
             response.AccessToken.Should().Be("access_token");
             response.RefreshToken.Should().Be("refresh_token");
             response.TryGet("custom").Should().Be("custom");

--- a/test/UnitTests/documents/success_token_response.json
+++ b/test/UnitTests/documents/success_token_response.json
@@ -1,7 +1,8 @@
 ﻿{
   "access_token": "access_token",
-  "expires_in": 3600,
+  "expires_in": 16078989860,
+  "auth_time": 1607898926,
   "token_type": "Bearer",
   "refresh_token": "refresh_token",
-  "custom":  "custom"
+  "custom": "custom"
 }


### PR DESCRIPTION
Fixes #363 
Related identitymodel/identitymodel.Oidcclient#277
- Exposes AuthTime value in response.
- Fixes EpiresIn value to be the correct value.  the value is a long and not int. 
    - Expiration time on or after which the ID Token MUST NOT be accepted for processing. The processing of this parameter requires that the current date/time MUST be before the expiration date/time listed in the value. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time. See RFC 3339 [RFC3339] for details regarding date/times in general and UTC in particular.
