### PR TITLE
Update TokenRequest.cs

### DIFF
--- a/src/Client/Messages/TokenRequest.cs
+++ b/src/Client/Messages/TokenRequest.cs
@@ -151,8 +151,11 @@ namespace IdentityModel.Client
         public string RefreshToken { get; set; }
 
         /// <summary>
-        /// Space separated list of the requested scopes
+        /// Space separated list of the requested scopes.  The Scope attribute cannot be used to extend the scopes granted by the resource owner
         /// </summary>
+        /// <remarks>
+        /// See https://datatracker.ietf.org/doc/html/rfc6749#section-6 for further detail on restrictions
+        /// </remarks>
         /// <value>
         /// The scope.
         /// </value>
@@ -162,7 +165,7 @@ namespace IdentityModel.Client
         /// List of requested resources
         /// </summary>
         /// <value>
-        /// The scope.
+        /// The resources.
         /// </value>
         public ICollection<string> Resource { get; set; } = new HashSet<string>();
     }


### PR DESCRIPTION
Got caught with this when walking through the tutorials as part of Identity Server.  This is linked to this issue https://github.com/IdentityServer/IdentityServer4/issues/5256

I think extending the documentation to be clear will prevent someone else from trying to misuse the Refresh Token flow to extend the scope.

