### PR TITLE
allow specifying the discovery document path

### DIFF
--- a/src/Client/DiscoveryEndpoint.cs
+++ b/src/Client/DiscoveryEndpoint.cs
@@ -12,12 +12,18 @@ namespace IdentityModel.Client
         /// Parses a URL and turns it into authority and discovery endpoint URL.
         /// </summary>
         /// <param name="input">The input.</param>
+        /// <param name="path">The path to the discovery document. If not specified this defaults to .well-known/open-id-configuration</param>
         /// <returns></returns>
         /// <exception cref="System.InvalidOperationException">
         /// Malformed URL
         /// </exception>
-        public static DiscoveryEndpoint ParseUrl(string input)
+        public static DiscoveryEndpoint ParseUrl(string input, string path = null)
         {
+            if (String.IsNullOrEmpty(path))
+            {
+                path = OidcConstants.Discovery.DiscoveryEndpoint;
+            }
+
             var success = Uri.TryCreate(input, UriKind.Absolute, out var uri);
             if (success == false)
             {
@@ -30,14 +36,18 @@ namespace IdentityModel.Client
             }
 
             var url = input.RemoveTrailingSlash();
-
-            if (url.EndsWith(OidcConstants.Discovery.DiscoveryEndpoint, StringComparison.OrdinalIgnoreCase))
+            if (path.StartsWith("/"))
             {
-                return new DiscoveryEndpoint(url.Substring(0, url.Length - OidcConstants.Discovery.DiscoveryEndpoint.Length - 1), url);
+                path = path.Substring(1);
+            }
+
+            if (url.EndsWith(path, StringComparison.OrdinalIgnoreCase))
+            {
+                return new DiscoveryEndpoint(url.Substring(0, url.Length - path.Length - 1), url);
             }
             else
             {
-                return new DiscoveryEndpoint(url, url.EnsureTrailingSlash() + OidcConstants.Discovery.DiscoveryEndpoint);
+                return new DiscoveryEndpoint(url, url.EnsureTrailingSlash() + path);
             }
         }
 

--- a/src/Client/DiscoveryPolicy.cs
+++ b/src/Client/DiscoveryPolicy.cs
@@ -18,6 +18,11 @@ namespace IdentityModel.Client
         public string Authority { get; set; }
 
         /// <summary>
+        /// The path of the discovery document. Defaults to /.well-known/openid-configuration.
+        /// </summary>
+        public string DiscoveryDocumentPath { get; set; }
+
+        /// <summary>
         /// Strategy used to validate issuer name and endpoints based on expected authority.
         /// Defaults to <see cref="AuthorityUrlValidationStrategy"/>.
         /// </summary>

--- a/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
+++ b/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
@@ -49,7 +49,7 @@ namespace IdentityModel.Client
                 throw new ArgumentException("An address is required.");
             }
 
-            var parsed = DiscoveryEndpoint.ParseUrl(address);
+            var parsed = DiscoveryEndpoint.ParseUrl(address, request.Policy.DiscoveryDocumentPath);
             var authority = parsed.Authority;
             var url = parsed.Url;
 

--- a/test/UnitTests/DiscoveryPolicyTests_WithoutAuthorityValidation.cs
+++ b/test/UnitTests/DiscoveryPolicyTests_WithoutAuthorityValidation.cs
@@ -35,5 +35,19 @@ namespace IdentityModel.UnitTests
             result.Authority.Should().Be("https://server:123");
         }
 
+        [Theory]
+        [InlineData("https://server:123/strange-location/openid-configuration", "/strange-location/openid-configuration")]
+        [InlineData("https://server:123/strange-location/openid-configuration", "strange-location/openid-configuration")]
+        [InlineData("https://server:123/strange-location/openid-configuration/", "/strange-location/openid-configuration")]
+        [InlineData("https://server:123/", "/strange-location/openid-configuration")]
+        [InlineData("https://server:123", "/strange-location/openid-configuration")]
+        public void Custom_path_is_supported(string input, string documentPath)
+        {
+            var result = DiscoveryEndpoint.ParseUrl(input, documentPath);
+
+            // test parse URL logic
+            result.Url.Should().Be("https://server:123/strange-location/openid-configuration");
+            result.Authority.Should().Be("https://server:123");
+        }
     }
 }


### PR DESCRIPTION
cleaned up version of the previous PR (https://github.com/IdentityModel/IdentityModel/pull/290 - originally from Feb 2020 -- this is squashed into a single commit and removes some local edits to the project files that were accidentally introduced later on)