### PR TITLE
Add scope to DynamicClientRegistrationDocument

### DIFF
--- a/src/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/src/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -57,6 +57,9 @@ namespace IdentityModel.Client
         [JsonPropertyName(OidcConstants.ClientMetadata.SubjectType)]
         public string SubjectType { get; set; }
 
+        [JsonPropertyName(OidcConstants.ClientMetadata.Scope)]
+        public string Scope { get; set; }
+
         [JsonPropertyName(OidcConstants.ClientMetadata.IdentityTokenSignedResponseAlgorithm)]
         public string IdentityTokenSignedResponseAlgorithm { get; set; }
 

--- a/src/OidcConstants.cs
+++ b/src/OidcConstants.cs
@@ -191,6 +191,7 @@ namespace IdentityModel
             public const string JwksUri = "jwks_uri";
             public const string Jwks = "jwks";
             public const string SectorIdentifierUri = "sector_identifier_uri";
+            public const string Scope = "scope";
             public const string SubjectType = "subject_type";
             public const string TokenEndpointAuthenticationMethod = "token_endpoint_auth_method";
             public const string TokenEndpointAuthenticationSigningAlgorithm = "token_endpoint_auth_signing_alg";


### PR DESCRIPTION
According to [RFC 7591 ](https://datatracker.ietf.org/doc/html/rfc7591#section-2) page 9 the dynamic client request may contain a `scope` property.

>   scope
      String containing a space-separated list of scope values (as
      described in Section 3.3 of OAuth 2.0 [RFC6749]) that the client
      can use when requesting access tokens.  The semantics of values in
      this list are service specific.  If omitted, an authorization
      server MAY register a client with a default set of scopes.