### PR TITLE
Change data type from string to Uri

### DIFF
--- a/src/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/src/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using IdentityModel.Jwk;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
@@ -47,7 +48,7 @@ namespace IdentityModel.Client
         public string ClientName { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.LogoUri)]
-        public string LogoUri { get; set; }
+        public Uri LogoUri { get; set; }
 
         /// <summary>
         /// Web page providing information about the client.
@@ -60,23 +61,23 @@ namespace IdentityModel.Client
         /// collects, uses, retains, and discloses personal data.
         /// </summary>
         [JsonPropertyName(OidcConstants.ClientMetadata.PolicyUri)]
-        public string PolicyUri { get; set; }
+        public Uri PolicyUri { get; set; }
 
         /// <summary>
         /// Human-readable terms of service document for the client that describes a contractual relationship
         /// between the end-user and the client that the end-user accepts when authorizing the client.
         /// </summary>
         [JsonPropertyName(OidcConstants.ClientMetadata.TosUri)]
-        public string TosUri { get; set; }
+        public Uri TosUri { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.JwksUri)]
-        public string JwksUri { get; set; }
+        public Uri JwksUri { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.Jwks)]
         public JsonWebKeySet Jwks { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.SectorIdentifierUri)]
-        public string SectorIdentifierUri { get; set; }
+        public Uri SectorIdentifierUri { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.SubjectType)]
         public string SubjectType { get; set; }
@@ -130,7 +131,7 @@ namespace IdentityModel.Client
         public ICollection<string> DefaultAcrValues { get; set; } = new HashSet<string>();
 
         [JsonPropertyName(OidcConstants.ClientMetadata.InitiateLoginUris)]
-        public string InitiateLoginUri { get; set; }
+        public Uri InitiateLoginUri { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.RequestUris)]
         public ICollection<string> RequestUris { get; set; } = new HashSet<string>();

--- a/src/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/src/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -26,7 +26,7 @@ namespace IdentityModel.Client
         /// Clients using flows with redirection must register their redirection URI values.
         /// </remarks>
         [JsonPropertyName(OidcConstants.ClientMetadata.RedirectUris)]
-        public ICollection<Uri> RedirectUris { get; set; } = new HashSet<string>();
+        public ICollection<Uri> RedirectUris { get; set; } = new HashSet<Uri>();
 
         /// <summary>
         /// List of the OAuth 2.0 response type strings that the client can use at the authorization endpoint.
@@ -184,7 +184,7 @@ namespace IdentityModel.Client
         public Uri InitiateLoginUri { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.RequestUris)]
-        public ICollection<Uri> RequestUris { get; set; } = new HashSet<string>();
+        public ICollection<Uri> RequestUris { get; set; } = new HashSet<Uri>();
         
         /// <summary>
         /// Custom client metadata fields to include in the serialization.

--- a/src/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/src/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -21,7 +21,7 @@ namespace IdentityModel.Client
     public class DynamicClientRegistrationDocument
     {
         [JsonPropertyName(OidcConstants.ClientMetadata.RedirectUris)]
-        public ICollection<string> RedirectUris { get; set; } = new HashSet<string>();
+        public ICollection<Uri> RedirectUris { get; set; } = new HashSet<string>();
 
         /// <summary>
         /// List of the OAuth 2.0 response type strings that the client can use at the authorization endpoint.
@@ -134,7 +134,7 @@ namespace IdentityModel.Client
         public Uri InitiateLoginUri { get; set; }
 
         [JsonPropertyName(OidcConstants.ClientMetadata.RequestUris)]
-        public ICollection<string> RequestUris { get; set; } = new HashSet<string>();
+        public ICollection<Uri> RequestUris { get; set; } = new HashSet<string>();
 
         // Don't serialize empty arrays
         public bool ShouldSerializeRequestUris() => RequestUris.Any();


### PR DESCRIPTION
Changes the data type from `string` to `Uri`.

Instead of weakly typed string we use strongly-typed `Uri` that accurately conveys the underlying data and ensures proper data and semantics through validation of input.

Closes #386.