### PR TITLE
Change default credential style to authorization header

### DIFF
--- a/src/Client/Messages/ProtocolRequest.cs
+++ b/src/Client/Messages/ProtocolRequest.cs
@@ -175,6 +175,12 @@ public class ProtocolRequest : HttpRequestMessage
 
         if (ClientAssertion?.Type != null && ClientAssertion.Value != null)
         {
+            if (ClientCredentialStyle == ClientCredentialStyle.AuthorizationHeader)
+            {
+                throw new InvalidOperationException(
+                    "CredentialStyle.AuthorizationHeader and client assertions are not compatible");
+            }
+            
             Parameters.AddOptional(OidcConstants.TokenRequest.ClientAssertionType, ClientAssertion.Type);
             Parameters.AddOptional(OidcConstants.TokenRequest.ClientAssertion, ClientAssertion.Value);
         }

--- a/src/Client/Messages/ProtocolRequest.cs
+++ b/src/Client/Messages/ProtocolRequest.cs
@@ -62,7 +62,7 @@ public class ProtocolRequest : HttpRequestMessage
     /// <value>
     /// The client credential style.
     /// </value>
-    public ClientCredentialStyle ClientCredentialStyle { get; set; } = ClientCredentialStyle.PostBody;
+    public ClientCredentialStyle ClientCredentialStyle { get; set; } = ClientCredentialStyle.AuthorizationHeader;
 
     /// <summary>
     /// Gets or sets the basic authentication header style (classic HTTP vs OAuth 2).

--- a/test/UnitTests/HttpClientExtensions/CibaExtensionsTests.cs
+++ b/test/UnitTests/HttpClientExtensions/CibaExtensionsTests.cs
@@ -56,7 +56,7 @@ namespace IdentityModel.UnitTests
             httpRequest.Content.Should().NotBeNull();
 
             var headers = httpRequest.Headers;
-            headers.Count().Should().Be(2);
+            headers.Count().Should().Be(3);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
             var properties = httpRequest.Properties;

--- a/test/UnitTests/HttpClientExtensions/DeviceAuthorizationExtensionsTests.cs
+++ b/test/UnitTests/HttpClientExtensions/DeviceAuthorizationExtensionsTests.cs
@@ -34,16 +34,15 @@ namespace IdentityModel.UnitTests
             request.Headers.Add("custom", "custom");
             request.Properties.Add("custom", "custom");
 
-            var response = await client.RequestDeviceAuthorizationAsync(request);
+            var _ = await client.RequestDeviceAuthorizationAsync(request);
 
             var httpRequest = handler.Request;
 
             httpRequest.Method.Should().Be(HttpMethod.Post);
             httpRequest.RequestUri.Should().Be(new Uri(Endpoint));
-            httpRequest.Content.Should().NotBeNull();
 
             var headers = httpRequest.Headers;
-            headers.Count().Should().Be(2);
+            headers.Count().Should().Be(3);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
             var properties = httpRequest.Properties;

--- a/test/UnitTests/HttpClientExtensions/TokenIntrospectionTests.cs
+++ b/test/UnitTests/HttpClientExtensions/TokenIntrospectionTests.cs
@@ -352,9 +352,8 @@ namespace IdentityModel.UnitTests
 
             // check request
             var fields = QueryHelpers.ParseQuery(handler.Body);
-            fields.Count.Should().Be(4);
-
-            fields["client_id"].First().Should().Be("client");
+            fields.Count.Should().Be(3);
+            
             fields["token"].First().Should().Be("token");
             fields["scope"].First().Should().Be("scope1 scope2");
             fields["foo"].First().Should().Be("bar");

--- a/test/UnitTests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
+++ b/test/UnitTests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
@@ -57,7 +57,7 @@ namespace IdentityModel.UnitTests
             httpRequest.Content.Should().NotBeNull();
 
             var headers = httpRequest.Headers;
-            headers.Count().Should().Be(2);
+            headers.Count().Should().Be(3);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
             var properties = httpRequest.Properties;
@@ -175,7 +175,7 @@ namespace IdentityModel.UnitTests
         }
 
         [Fact]
-        public void Explicit_null_parameters_should__not_fail_()
+        public void Explicit_null_parameters_should_not_fail_()
         {
             Func<Task> act = async () => await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest { ClientId = "client", Parameters = null });
 
@@ -196,10 +196,7 @@ namespace IdentityModel.UnitTests
             var fields = QueryHelpers.ParseQuery(_handler.Body);
             fields.TryGetValue("grant_type", out var grant_type).Should().BeTrue();
             grant_type.First().Should().Be(OidcConstants.GrantTypes.DeviceCode);
-
-            fields.TryGetValue("client_id", out var client_id).Should().BeTrue();
-            client_id.First().Should().Be("device");
-
+            
             fields.TryGetValue("device_code", out var device_code).Should().BeTrue();
             device_code.First().Should().Be("device_code");
         }

--- a/test/UnitTests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
+++ b/test/UnitTests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
@@ -71,8 +71,9 @@ namespace IdentityModel.UnitTests
         [Fact]
         public async Task No_explicit_endpoint_address_should_use_base_addess()
         {
-            var response = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest { ClientId = "client" });
-            
+            var response = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+                { ClientId = "client" });
+
             response.IsError.Should().BeFalse();
             _handler.Request.RequestUri.AbsoluteUri.Should().Be(Endpoint);
         }
@@ -114,7 +115,7 @@ namespace IdentityModel.UnitTests
             {
                 ClientId = "client",
                 Scope = "scope",
-                Resource =  { "resource1", "resource2" }
+                Resource = { "resource1", "resource2" }
             });
 
             response.IsError.Should().BeFalse();
@@ -125,7 +126,7 @@ namespace IdentityModel.UnitTests
 
             fields.TryGetValue("scope", out var scope).Should().BeTrue();
             scope.First().Should().Be("scope");
-            
+
             fields.TryGetValue("resource", out var resource).Should().BeTrue();
             resource.Count.Should().Be(2);
             resource[0].Should().Be("resource1");
@@ -150,7 +151,7 @@ namespace IdentityModel.UnitTests
             var headers = _handler.Request.Headers;
             var foo = headers.FirstOrDefault(h => h.Key == "foo");
             foo.Should().NotBeNull();
-            foo.Value.Single().Should().Be("bar");    
+            foo.Value.Single().Should().Be("bar");
         }
 
         [Fact]
@@ -177,7 +178,9 @@ namespace IdentityModel.UnitTests
         [Fact]
         public void Explicit_null_parameters_should_not_fail_()
         {
-            Func<Task> act = async () => await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest { ClientId = "client", Parameters = null });
+            Func<Task> act = async () =>
+                await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+                    { ClientId = "client", Parameters = null });
 
             act.Should().NotThrow();
         }
@@ -196,7 +199,7 @@ namespace IdentityModel.UnitTests
             var fields = QueryHelpers.ParseQuery(_handler.Body);
             fields.TryGetValue("grant_type", out var grant_type).Should().BeTrue();
             grant_type.First().Should().Be(OidcConstants.GrantTypes.DeviceCode);
-            
+
             fields.TryGetValue("device_code", out var device_code).Should().BeTrue();
             device_code.First().Should().Be("device_code");
         }
@@ -204,7 +207,8 @@ namespace IdentityModel.UnitTests
         [Fact]
         public void Device_request_without_device_code_should_fail()
         {
-            Func<Task> act = async () => await _client.RequestDeviceTokenAsync(new DeviceTokenRequest { ClientId = "device" });
+            Func<Task> act = async () =>
+                await _client.RequestDeviceTokenAsync(new DeviceTokenRequest { ClientId = "device" });
 
             act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("device_code");
         }
@@ -235,7 +239,7 @@ namespace IdentityModel.UnitTests
 
             fields.TryGetValue("scope", out var scope).Should().BeTrue();
             scope.First().Should().Be("scope");
-            
+
             fields.TryGetValue("resource", out var resource).Should().BeTrue();
             resource.Count.Should().Be(2);
             resource[0].Should().Be("resource1");
@@ -267,7 +271,7 @@ namespace IdentityModel.UnitTests
         [Fact]
         public void Password_request_without_username_should_fail()
         {
-           Func<Task> act = async () => await _client.RequestPasswordTokenAsync(new PasswordTokenRequest());
+            Func<Task> act = async () => await _client.RequestPasswordTokenAsync(new PasswordTokenRequest());
 
             act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("username");
         }
@@ -298,7 +302,7 @@ namespace IdentityModel.UnitTests
 
             fields.TryGetValue("code_verifier", out var code_verifier).Should().BeTrue();
             code_verifier.First().Should().Be("verifier");
-            
+
             fields.TryGetValue("resource", out var resource).Should().BeTrue();
             resource.Count.Should().Be(2);
             resource[0].Should().Be("resource1");
@@ -308,10 +312,11 @@ namespace IdentityModel.UnitTests
         [Fact]
         public void Code_request_without_code_should_fail()
         {
-            Func<Task> act = async () => await _client.RequestAuthorizationCodeTokenAsync(new AuthorizationCodeTokenRequest
-            {
-                RedirectUri = "uri"
-            });
+            Func<Task> act = async () => await _client.RequestAuthorizationCodeTokenAsync(
+                new AuthorizationCodeTokenRequest
+                {
+                    RedirectUri = "uri"
+                });
 
             act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("code");
         }
@@ -319,10 +324,11 @@ namespace IdentityModel.UnitTests
         [Fact]
         public void Code_request_without_redirect_uri_should_fail()
         {
-            Func<Task> act = async () => await _client.RequestAuthorizationCodeTokenAsync(new AuthorizationCodeTokenRequest
-            {
-                Code = "code"
-            });
+            Func<Task> act = async () => await _client.RequestAuthorizationCodeTokenAsync(
+                new AuthorizationCodeTokenRequest
+                {
+                    Code = "code"
+                });
 
             act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("redirect_uri");
         }
@@ -349,7 +355,7 @@ namespace IdentityModel.UnitTests
 
             fields.TryGetValue("scope", out var redirect_uri).Should().BeTrue();
             redirect_uri.First().Should().Be("scope");
-            
+
             fields.TryGetValue("resource", out var resource).Should().BeTrue();
             resource.Count.Should().Be(2);
             resource[0].Should().Be("resource1");
@@ -363,21 +369,21 @@ namespace IdentityModel.UnitTests
 
             act.Should().Throw<ArgumentException>().And.ParamName.Should().Be("refresh_token");
         }
-        
+
         [Fact]
         public async Task TokenExchange_request_should_have_correct_format()
         {
             var response = await _client.RequestTokenExchangeTokenAsync(new TokenExchangeTokenRequest
             {
                 ClientId = "client",
-                
+
                 SubjectToken = "subject_token",
                 SubjectTokenType = "subject_token_type",
-                
+
                 Scope = "scope",
                 Resource = "resource",
                 Audience = "audience",
-                
+
                 ActorToken = "actor_token",
                 ActorTokenType = "actor_token_type"
             });
@@ -396,16 +402,16 @@ namespace IdentityModel.UnitTests
 
             fields.TryGetValue("scope", out var scope).Should().BeTrue();
             scope.First().Should().Be("scope");
-            
+
             fields.TryGetValue("resource", out var resource).Should().BeTrue();
             resource.First().Should().Be("resource");
-            
+
             fields.TryGetValue("audience", out var audience).Should().BeTrue();
             audience.First().Should().Be("audience");
-            
+
             fields.TryGetValue("actor_token", out var actor_token).Should().BeTrue();
             actor_token.First().Should().Be("actor_token");
-            
+
             fields.TryGetValue("actor_token_type", out var actor_token_type).Should().BeTrue();
             actor_token_type.First().Should().Be("actor_token_type");
         }
@@ -484,7 +490,7 @@ namespace IdentityModel.UnitTests
                 { "client_secret", "secret" },
                 { "scope", "scope" }
             });
-            
+
             var request = _handler.Request;
 
             request.RequestUri.AbsoluteUri.Should().Be("https://token/");
@@ -520,7 +526,8 @@ namespace IdentityModel.UnitTests
 
             request.Headers.Authorization.Should().NotBeNull();
             request.Headers.Authorization.Scheme.Should().Be("Basic");
-            request.Headers.Authorization.Parameter.Should().Be(BasicAuthenticationOAuthHeaderValue.EncodeCredential("client", "secret"));
+            request.Headers.Authorization.Parameter.Should()
+                .Be(BasicAuthenticationOAuthHeaderValue.EncodeCredential("client", "secret"));
         }
 
         [Fact]
@@ -540,9 +547,8 @@ namespace IdentityModel.UnitTests
             var fields = QueryHelpers.ParseQuery(_handler.Body);
             fields["client_id"].First().Should().Be("client");
             fields["client_secret"].First().Should().Be("secret");
-
         }
-        
+
         [Fact]
         public async Task Setting_client_id_only_and_post_should_put_client_id_in_post_body()
         {
@@ -575,11 +581,27 @@ namespace IdentityModel.UnitTests
 
             request.Headers.Authorization.Should().NotBeNull();
             request.Headers.Authorization.Scheme.Should().Be("Basic");
-            request.Headers.Authorization.Parameter.Should().Be(BasicAuthenticationOAuthHeaderValue.EncodeCredential("client", ""));
+            request.Headers.Authorization.Parameter.Should()
+                .Be(BasicAuthenticationOAuthHeaderValue.EncodeCredential("client", ""));
 
             var fields = QueryHelpers.ParseQuery(_handler.Body);
             fields.TryGetValue("client_secret", out _).Should().BeFalse();
             fields.TryGetValue("client_id", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Setting_client_id_and_assertion_with_authorization_header_should_fail()
+        {
+            Func<Task> act = () => _client.RequestTokenAsync(new TokenRequest
+            {
+                GrantType = "test",
+                ClientId = "client",
+                ClientAssertion = { Type = "type", Value = "value" },
+                ClientCredentialStyle = ClientCredentialStyle.AuthorizationHeader
+            });
+
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("CredentialStyle.AuthorizationHeader and client assertions are not compatible");
         }
 
         [Fact]
@@ -589,7 +611,8 @@ namespace IdentityModel.UnitTests
             {
                 GrantType = "test",
                 ClientId = "client",
-                ClientAssertion = { Type = "type", Value = "value" }
+                ClientAssertion = { Type = "type", Value = "value" },
+                ClientCredentialStyle = ClientCredentialStyle.PostBody
             });
 
             var request = _handler.Request;

--- a/test/UnitTests/HttpClientExtensions/TokenRevocationExtensions.cs
+++ b/test/UnitTests/HttpClientExtensions/TokenRevocationExtensions.cs
@@ -196,10 +196,8 @@ namespace IdentityModel.UnitTests
 
             // check request
             var fields = QueryHelpers.ParseQuery(handler.Body);
-            fields.Count.Should().Be(4);
-
-            fields["client_id"].First().Should().Be("client");
-            fields["client_secret"].First().Should().Be("secret");
+            fields.Count.Should().Be(2);
+            
             fields["token"].First().Should().Be("token");
             fields["foo"].First().Should().Be("bar");
 


### PR DESCRIPTION
The OAuth spec recommends to send client credentials on the authorization header - and not in the post body.

Since many server implementations had the wrong header encoding implementations, IdentityModel preferred the post body approach. A major new version would have the opportunity to change this behavior.