### PR TITLE
Don't wrap OperationCanceledException in a protocol response

### DIFF
--- a/src/Client/Extensions/HttpClientBackchannelAuthenticationExtensions.cs
+++ b/src/Client/Extensions/HttpClientBackchannelAuthenticationExtensions.cs
@@ -59,6 +59,10 @@ public static class HttpClientBackchannelAuthenticationExtensions
         {
             response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<BackchannelAuthenticationResponse>(ex);

--- a/src/Client/Extensions/HttpClientDeviceFlowExtensions.cs
+++ b/src/Client/Extensions/HttpClientDeviceFlowExtensions.cs
@@ -34,6 +34,10 @@ public static class HttpClientDeviceFlowExtensions
         {
             response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<DeviceAuthorizationResponse>(ex);

--- a/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
+++ b/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
@@ -117,10 +117,18 @@ public static class HttpClientDiscoveryExtensions
 
                 return disco;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 return ProtocolResponse.FromException<DiscoveryDocumentResponse>(ex, $"Error connecting to {jwkUrl}. {ex.Message}.");
             }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
+++ b/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
@@ -41,6 +41,10 @@ public static class HttpClientDynamicRegistrationExtensions
         {
             response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<DynamicClientRegistrationResponse>(ex);

--- a/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
+++ b/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
@@ -62,6 +62,10 @@ public static class HttpClientJsonWebKeySetExtensions
                 return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response, $"Error connecting to {clone.RequestUri.AbsoluteUri}: {response.ReasonPhrase}").ConfigureAwait();
             }
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<JsonWebKeySetResponse>(ex, $"Error connecting to {clone.RequestUri.AbsoluteUri}. {ex.Message}.");

--- a/src/Client/Extensions/HttpClientTokenIntrospectionExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenIntrospectionExtensions.cs
@@ -35,6 +35,10 @@ public static class HttpClientTokenIntrospectionExtensions
         {
             response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<TokenIntrospectionResponse>(ex);

--- a/src/Client/Extensions/HttpClientTokenRequestExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenRequestExtensions.cs
@@ -222,6 +222,10 @@ public static class HttpClientTokenRequestExtensions
         {
             response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
         }
+        catch (OperationCanceledException)
+		{
+            throw;
+		}
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<TokenResponse>(ex);

--- a/src/Client/Extensions/HttpClientTokenRevocationExtensions.cs
+++ b/src/Client/Extensions/HttpClientTokenRevocationExtensions.cs
@@ -35,6 +35,10 @@ public static class HttpClientTokenRevocationExtensions
         {
             response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<TokenRevocationResponse>(ex);

--- a/src/Client/Extensions/HttpClientUserInfoExtensions.cs
+++ b/src/Client/Extensions/HttpClientUserInfoExtensions.cs
@@ -36,6 +36,10 @@ public static class HttpClientUserInfoExtensions
         {
             response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<UserInfoResponse>(ex);


### PR DESCRIPTION
Fixes #176

I've gone through and handled all of the instances where an exception is serialized into a ProtocolResponse and ignored OperationCanceledException types.

I haven't done it the same as #176 suggested as I (personally) find this method easier to read. Happy to be overruled though