### PR TITLE
Update JsonWebKeySet with RawData property

### DIFF
--- a/src/Jwk/JsonWebKeySet.cs
+++ b/src/Jwk/JsonWebKeySet.cs
@@ -54,6 +54,8 @@ public class JsonWebKeySet
 
         var jwebKeys = JsonSerializer.Deserialize<JsonWebKeySet>(json);
         Keys = jwebKeys.Keys;
+        
+        RawData = json;
     }
 
     /// <summary>
@@ -61,4 +63,10 @@ public class JsonWebKeySet
     /// </summary>
     [JsonPropertyName("keys")]
     public List<JsonWebKey> Keys { get; set; } = new();
+    
+    /// <summary>
+    /// The JSON string used to deserialize this object
+    /// </summary>
+    [JsonIgnore]
+    public string RawData { get; set; };
 }


### PR DESCRIPTION
Consumers may want to access the raw JSON string that was used to deserialize the `JsonWebKeySet` object to use with other packages such as `Microsoft.IdentityModel.Tokens.JsonWebKeySet`. This avoids having to serialize the object again, or making a second REST call to the identity server to get the JSON string.