### PR TITLE
Add "roles" to standard claim types

### DIFF
--- a/src/JwtClaimTypes.cs
+++ b/src/JwtClaimTypes.cs
@@ -157,6 +157,11 @@ public static class JwtClaimTypes
     public const string Role = "role";
 
     /// <summary>
+    /// The roles
+    /// </summary>
+    public const string Roles = "roles";
+
+    /// <summary>
     /// The reference token identifier
     /// </summary>
     public const string ReferenceTokenId = "reference_token_id";


### PR DESCRIPTION
Add "roles" to JwtClaimTypes. "roles" is a [registered claim type](https://www.iana.org/assignments/jwt/jwt.xhtml#table-claims) supported by [RFC 9068](https://www.rfc-editor.org/rfc/rfc9068.html#name-claims-for-authorization-ou) for use with OAuth2. 

This resolves #517, though without deprecating the constant for the "role" claim.