### PR TITLE
Enable Trimmable Assembly

### DIFF
--- a/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
+++ b/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using IdentityModel.Internal;
+using IdentityModel.Jwk;
 using System;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,17 +24,16 @@ public static class HttpClientDynamicRegistrationExtensions
     /// <param name="request">The request.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns></returns>
-    public static async Task<DynamicClientRegistrationResponse> RegisterClientAsync(this HttpMessageInvoker client, DynamicClientRegistrationRequest request, CancellationToken cancellationToken = default)
+    public static async Task<DynamicClientRegistrationResponse> RegisterClientAsync(
+        this HttpMessageInvoker client, DynamicClientRegistrationRequest request, CancellationToken cancellationToken = default)
     {
         var clone = request.Clone();
 
-        var options = new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-
         clone.Method = HttpMethod.Post;
-        clone.Content = new StringContent(JsonSerializer.Serialize(request.Document, options), Encoding.UTF8, "application/json");
+        clone.Content = new StringContent(
+            JsonSerializer.Serialize(request.Document, ClientMessagesSourceGenerationContext.Default.DynamicClientRegistrationDocument),
+            Encoding.UTF8,
+            "application/json");
         clone.Prepare();
 
         if (request.Token!.IsPresent())

--- a/src/Client/Messages/ClientMessagesSourceGenerationContext.cs
+++ b/src/Client/Messages/ClientMessagesSourceGenerationContext.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace IdentityModel.Client;
+
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(DynamicClientRegistrationDocument))]
+internal partial class ClientMessagesSourceGenerationContext : JsonSerializerContext
+{
+}

--- a/src/IdentityModel.csproj
+++ b/src/IdentityModel.csproj
@@ -10,6 +10,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+
+    <!-- Enable Trimming Warnings to allow consumers to publish as trimmed -->
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jwk/JsonWebKeySet.cs
+++ b/src/Jwk/JsonWebKeySet.cs
@@ -53,7 +53,7 @@ public class JsonWebKeySet
     {
         if (string.IsNullOrWhiteSpace(json)) throw new ArgumentNullException(nameof(json));
 
-        var jwebKeys = JsonSerializer.Deserialize<JsonWebKeySet>(json);
+        var jwebKeys = JsonSerializer.Deserialize<JsonWebKeySet>(json, JwkSourceGenerationContext.Default.JsonWebKeySet);
         if (jwebKeys == null) throw new InvalidOperationException("invalid JSON web keys");
         
         Keys = jwebKeys.Keys;

--- a/src/Jwk/JsonWebkey.cs
+++ b/src/Jwk/JsonWebkey.cs
@@ -60,7 +60,7 @@ public class JsonWebKey
     {
         if (string.IsNullOrWhiteSpace(json)) throw new ArgumentNullException(nameof(json));
 
-        var key = JsonSerializer.Deserialize<JsonWebKey>(json);
+        var key = JsonSerializer.Deserialize<JsonWebKey>(json, JwkSourceGenerationContext.Default.JsonWebKey);
         if (key == null) throw new InvalidOperationException("malformed key");
 
         Copy(key);

--- a/src/Jwk/JwkExtensions.cs
+++ b/src/Jwk/JwkExtensions.cs
@@ -19,7 +19,7 @@ public static class JsonWebKeyExtensions
     /// <returns></returns>
     public static string ToJwkString(this JsonWebKey key)
     {
-        var json = JsonSerializer.Serialize(key);            
+        var json = JsonSerializer.Serialize(key, JwkSourceGenerationContext.Default.JsonWebKey);
         return Base64Url.Encode(Encoding.UTF8.GetBytes(json));
     }
 }

--- a/src/Jwk/JwkSourceGenerationContext.cs
+++ b/src/Jwk/JwkSourceGenerationContext.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace IdentityModel.Jwk;
+
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(JsonWebKey))]
+[JsonSerializable(typeof(JsonWebKeySet))]
+internal partial class JwkSourceGenerationContext : JsonSerializerContext
+{
+}


### PR DESCRIPTION
With this change I am annotating the core assembly as IsTrimmable. This enables warnings for any known issues that may arise when publishing a final project as trimmed. The only warnings present were the use of runtime reflection code to perform the Json serialization. I converted over to using the Json Source Generator to move this logic from runtime to compile time (a net performance win too).