### PR TITLE
Improve nullable annotations for IsMissing/IsPresent string extensions

### DIFF
--- a/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
+++ b/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
@@ -36,7 +36,7 @@ public static class HttpClientDiscoveryExtensions
     public static async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(this HttpMessageInvoker client, DiscoveryDocumentRequest request, CancellationToken cancellationToken = default)
     {
         string address;
-        if (request.Address!.IsPresent())
+        if (request.Address.IsPresent())
         {
             address = request.Address!;
         }

--- a/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
+++ b/src/Client/Extensions/HttpClientDynamicRegistrationExtensions.cs
@@ -37,7 +37,7 @@ public static class HttpClientDynamicRegistrationExtensions
         clone.Content = new StringContent(JsonSerializer.Serialize(request.Document, options), Encoding.UTF8, "application/json");
         clone.Prepare();
 
-        if (request.Token!.IsPresent())
+        if (request.Token.IsPresent())
         {
             clone.SetBearerToken(request.Token!);
         }

--- a/src/Client/Extensions/HttpClientUserInfoExtensions.cs
+++ b/src/Client/Extensions/HttpClientUserInfoExtensions.cs
@@ -23,7 +23,7 @@ public static class HttpClientUserInfoExtensions
     /// <returns></returns>
     public static async Task<UserInfoResponse> GetUserInfoAsync(this HttpMessageInvoker client, UserInfoRequest request, CancellationToken cancellationToken = default)
     {
-        if (request.Token!.IsMissing()) throw new ArgumentNullException(nameof(request.Token));
+        if (request.Token.IsMissing()) throw new ArgumentNullException(nameof(request.Token));
 
         var clone = request.Clone();
 

--- a/src/Client/Messages/AuthorizeResponse.cs
+++ b/src/Client/Messages/AuthorizeResponse.cs
@@ -125,7 +125,7 @@ public class AuthorizeResponse
     /// <value>
     ///   <c>true</c> if the response is an error; otherwise, <c>false</c>.
     /// </value>
-    public bool IsError => Error!.IsPresent();
+    public bool IsError => Error.IsPresent();
 
     /// <summary>
     /// Gets the expires in.

--- a/src/Client/Messages/Parameters.cs
+++ b/src/Client/Messages/Parameters.cs
@@ -33,7 +33,7 @@ public class Parameters : List<KeyValuePair<string, string>>
         foreach (var prop in values.GetType().GetRuntimeProperties())
         {
             var value = prop.GetValue(values) as string;
-            if (value!.IsPresent())
+            if (value.IsPresent())
             {
                 dictionary.Add(prop.Name, value!);
             }
@@ -132,7 +132,7 @@ public class Parameters : List<KeyValuePair<string, string>>
             }
         }
 
-        if (value!.IsPresent())
+        if (value.IsPresent())
         {
             Add(key, value!);
         }
@@ -160,7 +160,7 @@ public class Parameters : List<KeyValuePair<string, string>>
             }
         }
             
-        if (value!.IsPresent() || allowEmptyValue)
+        if (value.IsPresent() || allowEmptyValue)
         {
             Add(key, value!);
         }

--- a/src/Client/Messages/ProtocolRequest.cs
+++ b/src/Client/Messages/ProtocolRequest.cs
@@ -191,12 +191,12 @@ public class ProtocolRequest : HttpRequestMessage
             Parameters.AddOptional(OidcConstants.TokenRequest.ClientAssertion, ClientAssertion.Value);
         }
 
-        if (Address!.IsPresent())
+        if (Address.IsPresent())
         {
             RequestUri = new Uri(Address!, UriKind.RelativeOrAbsolute);
         }
 
-        if (DPoPProofToken!.IsPresent())
+        if (DPoPProofToken.IsPresent())
         {
             Headers.Add(OidcConstants.HttpHeaders.DPoP, DPoPProofToken);
         }

--- a/src/Client/Messages/ProtocolResponse.cs
+++ b/src/Client/Messages/ProtocolResponse.cs
@@ -45,7 +45,7 @@ public class ProtocolResponse
         {
             response.ErrorType = ResponseErrorType.Http;
 
-            if (content!.IsPresent())
+            if (content.IsPresent())
             {
                 try
                 {
@@ -66,7 +66,7 @@ public class ProtocolResponse
         // either 200 or 400 - both cases need a JSON response (if present), otherwise error
         try
         {
-            if (content!.IsPresent())
+            if (content.IsPresent())
             {
                 response.Json = JsonDocument.Parse(content!).RootElement;
             }
@@ -156,7 +156,7 @@ public class ProtocolResponse
     /// <value>
     ///   <c>true</c> if an error occurred; otherwise, <c>false</c>.
     /// </value>
-    public bool IsError => Error!.IsPresent() || ErrorType != ResponseErrorType.None;
+    public bool IsError => Error.IsPresent() || ErrorType != ResponseErrorType.None;
 
     /// <summary>
     /// Gets the type of the error.
@@ -200,7 +200,7 @@ public class ProtocolResponse
     {
         get
         {
-            if (ErrorMessage!.IsPresent())
+            if (ErrorMessage.IsPresent())
             {
                 return ErrorMessage;
             }

--- a/src/Internal/InternalStringExtensions.cs
+++ b/src/Internal/InternalStringExtensions.cs
@@ -10,13 +10,13 @@ namespace IdentityModel.Internal;
 internal static class InternalStringExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
+    public static bool IsMissing(this string? value)
     {
         return string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static bool IsPresent(this string value)
+    public static bool IsPresent(this string? value)
     {
         return !(value.IsMissing());
     }


### PR DESCRIPTION
By declaring `string? value` as nullable we can get rid of many null-forgiving operators throughout the code.