### PR TITLE
Fix NullReferenceException in ProtocolResponse.FromHttpResponseAsync

### DIFF
--- a/src/Client/Messages/ProtocolResponse.cs
+++ b/src/Client/Messages/ProtocolResponse.cs
@@ -30,6 +30,13 @@ public class ProtocolResponse
             HttpResponse = httpResponse
         };
 
+        // Probably a connection error, no HttpResponseMessage
+        if (httpResponse == null)
+        {
+            await response.InitializeAsync(initializationData).ConfigureAwait();
+            return response;
+        }
+
         // try to read content
         string? content = null;
         try


### PR DESCRIPTION
Addresses https://github.com/IdentityModel/IdentityModel/issues/532 by returning early in `ProtocolResponse.FromHttpResponseAsync` if there is no `HttpResponseMessage` to process for more details