### PR TITLE
Change to Dictionary<string, JsonElement> for DCR extension data

### DIFF
--- a/src/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/src/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -5,6 +5,7 @@ using IdentityModel.Jwk;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 #pragma warning disable 1591
@@ -279,7 +280,7 @@ public class DynamicClientRegistrationDocument
     /// Custom client metadata fields to include in the serialization.
     /// </summary>
     [JsonExtensionData]
-    public IDictionary<string, object>? Extensions { get; set; } = new Dictionary<string, object>(StringComparer.Ordinal);
+    public IDictionary<string, JsonElement>? Extensions { get; set; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
 
     // Don't serialize empty arrays
     public bool ShouldSerializeRequestUris() => RequestUris.Any();

--- a/src/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/src/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -279,7 +279,7 @@ public class DynamicClientRegistrationDocument
     /// Custom client metadata fields to include in the serialization.
     /// </summary>
     [JsonExtensionData]
-    public IDictionary<string, object>? Extensions { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+    public IDictionary<string, object>? Extensions { get; set; } = new Dictionary<string, object>(StringComparer.Ordinal);
 
     // Don't serialize empty arrays
     public bool ShouldSerializeRequestUris() => RequestUris.Any();


### PR DESCRIPTION
This changes the DCR model to use Dictionary<string, **JsonElement**> as the type of its extension data.

The existing Dictionary<string, **object**> can't be serialized with source generated serialization.