### PR TITLE
Add trimmable analysis project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup SKDs
+    - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
+          8.0.x
 
     - run: dotnet --info
     

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,8 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
-      
+          8.0.x
+
     - run: dotnet --info
 
     # Initializes the CodeQL tools for scanning.

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -22,6 +22,7 @@ namespace build
             public const string Pack = "pack";
             public const string SignBinary = "sign-binary";
             public const string SignPackage = "sign-package";
+            public const string TrimmableAnalysis = "trimmable-analysis";
         }
 
         static async Task Main(string[] args)
@@ -62,6 +63,11 @@ namespace build
             Target(Targets.SignPackage, DependsOn(Targets.Pack, Targets.RestoreTools), () =>
             {
                 SignNuGet();
+            });
+
+            Target(Targets.TrimmableAnalysis, () =>
+            {
+                Run("dotnet", "publish test/TrimmableAnalysis -c Release -r win-x64");
             });
 
             Target("default", DependsOn(Targets.Test, Targets.Pack));

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -70,9 +70,9 @@ namespace build
                 Run("dotnet", "publish test/TrimmableAnalysis -c Release -r win-x64");
             });
 
-            Target("default", DependsOn(Targets.Test, Targets.Pack));
+            Target("default", DependsOn(Targets.Test, Targets.Pack, Targets.TrimmableAnalysis));
 
-            Target("sign", DependsOn(Targets.Test, Targets.SignPackage));
+            Target("sign", DependsOn(Targets.Test, Targets.SignPackage, Targets.TrimmableAnalysis));
 
             await RunTargetsAndExitAsync(args, ex => ex is SimpleExec.ExitCodeException || ex.Message.EndsWith(envVarMissing));
         }

--- a/src/Client/Messages/Parameters.cs
+++ b/src/Client/Messages/Parameters.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq;
 using System.Reflection;
 using IdentityModel.Internal;
@@ -16,6 +19,9 @@ public class Parameters : List<KeyValuePair<string, string>>
     /// </summary>
     /// <param name="values"></param>
     /// <returns></returns>
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode("The FromObject method uses reflection in a way that is incompatible with trimming.")]
+#endif
     public static Parameters? FromObject(object values)
     {
         if (values == null)

--- a/test/TrimmableAnalysis/Program.cs
+++ b/test/TrimmableAnalysis/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/test/TrimmableAnalysis/README.md
+++ b/test/TrimmableAnalysis/README.md
@@ -1,0 +1,3 @@
+This project exists to facilitate analysis of trimmable warnings. 
+
+See https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming

--- a/test/TrimmableAnalysis/TrimmableAnalysis.csproj
+++ b/test/TrimmableAnalysis/TrimmableAnalysis.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors> 
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="IdentityModel" />
+    <ProjectReference Include="..\..\src\IdentityModel.csproj" /> 
+  </ItemGroup>
+
+</Project>

--- a/test/UnitTests/Infrastructure/FileName.cs
+++ b/test/UnitTests/Infrastructure/FileName.cs
@@ -9,7 +9,7 @@ namespace IdentityModel.UnitTests
     {
         public static string Create(string name)
         {
-#if NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NET6_0 || NET7_0
+#if NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0 || NET6_0 || NET7_0 || NET8_0
             var fullName = Path.Combine(System.AppContext.BaseDirectory, "documents", name);
 #else
             var fullName = Path.Combine(Microsoft.Extensions.PlatformAbstractions.PlatformServices.Default.Application.ApplicationBasePath, "documents", name);

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -7,11 +7,11 @@
 
     <!--Conditional compilation-->
     <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-        <TargetFrameworks>net462;net472;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net462;net472;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' and '$(NETCoreSdkPortableRuntimeIdentifier)' != 'osx-arm64' ">
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(NETCoreSdkPortableRuntimeIdentifier)' == 'osx-arm64' ">
@@ -35,7 +35,7 @@
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or $(TargetFramework) == 'net7.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or $(TargetFramework) == 'net7.0' or $(TargetFramework) == 'net8.0'">
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     </ItemGroup>
 


### PR DESCRIPTION
This adds a project that references the library with trimming enabled, to ensure we don't have anything that isn't trimmable friendly. This style of analysis is recommended by the MS docs on [preparing libraries for trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?pivots=dotnet-8-0).

This analysis found that the Parameters.FromObject method was not trimmable friendly. Using reflection the way that it does is not something that can be trimmed. To quote the docs:

> Because there's no way to know at publish-time what type name is going to be used, there's no way for the trimmer to know which type to preserve in the output.

For that reason, the method has been marked as `[RequiresUnreferencedCode]`. This marks the method as not trimmable, and propagates the warning out of our library into the caller if they attempt to use the method with trimming enabled.

This PR also adds .NET 8 _in the tests only_ as a TargetFramework. We previously have included net6.0 and net7.0 in the tests even though we only need net6.0 in the library itself. I think the same is true of net8.0 and that we should follow that pattern.