### PR TITLE
Add constructor to DiscoveryCache to dynamically resolve authority URL

### DIFF
--- a/test/UnitTests/DiscoveryCacheTests.cs
+++ b/test/UnitTests/DiscoveryCacheTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+using System;
+using FluentAssertions;
 using IdentityModel.Client;
 using System.IO;
 using System.Net;
@@ -41,6 +42,26 @@ namespace IdentityModel.UnitTests
             var disco = await cache.GetAsync();
 
             disco.IsError.Should().BeFalse();
+        }
+        
+        [Fact]
+        public async Task Authority_should_be_reevaluated_after_calling_refresh()
+        {
+            var numberOfTimesCalled = 0;
+            Func<string> authorityFunc = () => {
+                numberOfTimesCalled++;
+                return _authority;
+            };
+            
+            var client = new HttpClient(_successHandler);
+            var cache = new DiscoveryCache(authorityFunc, () => client);
+            
+            _ = await cache.GetAsync();
+            _ = await cache.GetAsync();
+            cache.Refresh();
+            _ = await cache.GetAsync();
+            
+            numberOfTimesCalled.Should().Be(2);
         }
     }
 }


### PR DESCRIPTION
Existing constructor does not support passing in a `Func<string>` to resolve the base address/discovery document endpoint. This means if the endpoint URL changes dynamically and we wish to bust the cache, we have to replace the entire object instance as calling `Refresh()` will not work.

Added Constructor:
`public DiscoveryCache(Func<string> authorityFunc, Func<HttpMessageInvoker> httpClientFunc, DiscoveryPolicy? policy = null)`

Added additional unit tests for `DiscoveryCache`.