### PR TITLE
Error Handling Improvements

### DIFF
--- a/src/Client/AuthorityUrlValidationStrategy.cs
+++ b/src/Client/AuthorityUrlValidationStrategy.cs
@@ -67,6 +67,7 @@ public sealed class AuthorityUrlValidationStrategy : IAuthorityValidationStrateg
 
         }
 
-        return AuthorityValidationResult.CreateError($"Endpoint belongs to different authority: {endpoint}");
+        var expectedBaseAddresses = string.Join(",", allowedAuthorities);
+        return AuthorityValidationResult.CreateError($"Invalid base address for endpoint {endpoint}. Valid base addresses: {expectedBaseAddresses}.");
     }
 }

--- a/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
+++ b/src/Client/Extensions/HttpClientJsonWebKeySetExtensions.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace IdentityModel.Client;
 
 /// <summary>
-/// HttpClient extentions for OIDC discovery
+/// HttpClient extensions for OIDC discovery
 /// </summary>
 public static class HttpClientJsonWebKeySetExtensions
 {

--- a/src/Client/Messages/DiscoveryDocumentResponse.cs
+++ b/src/Client/Messages/DiscoveryDocumentResponse.cs
@@ -22,7 +22,7 @@ public class DiscoveryDocumentResponse : ProtocolResponse
 
     protected override Task InitializeAsync(object? initializationData = null)
     {
-        if (!HttpResponse.IsSuccessStatusCode)
+        if (HttpResponse?.IsSuccessStatusCode != true)
         {
             ErrorMessage = initializationData as string;
             return Task.CompletedTask;

--- a/src/Client/Messages/JsonWebKeySetResponse.cs
+++ b/src/Client/Messages/JsonWebKeySetResponse.cs
@@ -13,13 +13,13 @@ namespace IdentityModel.Client;
 public class JsonWebKeySetResponse : ProtocolResponse
 {
     /// <summary>
-    /// Intializes the key set
+    /// Initializes the key set
     /// </summary>
     /// <param name="initializationData"></param>
     /// <returns></returns>
     protected override Task InitializeAsync(object? initializationData = null)
     {
-        if (!HttpResponse.IsSuccessStatusCode)
+        if (HttpResponse?.IsSuccessStatusCode != true)
         {
             ErrorMessage = initializationData as string;
         }

--- a/src/Client/Messages/ProtocolResponse.cs
+++ b/src/Client/Messages/ProtocolResponse.cs
@@ -41,12 +41,11 @@ public class ProtocolResponse
         catch { }
 
         // some HTTP error - try to parse body as JSON but allow non-JSON as well
-        if (httpResponse.IsSuccessStatusCode == false &&
+        if (httpResponse.IsSuccessStatusCode != true &&
             httpResponse.StatusCode != HttpStatusCode.BadRequest)
         {
             response.ErrorType = ResponseErrorType.Http;
 
-            if (content.IsPresent())
             if (!skipJson && content.IsPresent())
             {
                 try
@@ -129,7 +128,7 @@ public class ProtocolResponse
     /// <value>
     /// The HTTP response.
     /// </value>
-    public HttpResponseMessage HttpResponse { get; protected set; } = default!;
+    public HttpResponseMessage? HttpResponse { get; protected set; }
         
     /// <summary>
     /// Gets the raw protocol response (if present).

--- a/src/Client/Messages/ProtocolResponse.cs
+++ b/src/Client/Messages/ProtocolResponse.cs
@@ -32,13 +32,25 @@ public class ProtocolResponse
         };
 
         // try to read content
-        string? content = null;
+        var content = string.Empty;
         try
         {
-            content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait();
+            // In .NET, empty content is represented in an HttpResponse with the EmptyContent type,
+            // the Content property is not nullable, and ReadAsStringAsync returns the empty string.
+            //
+            // BUT, in .NET Framework, empty content is represented with a null, and attempting to
+            // call ReadAsStringAsync would throw a NRE.
+            if (httpResponse.Content != null)
+            {
+                content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait();
+            }
             response.Raw = content;
         }
-        catch { }
+        catch (Exception ex)
+        {
+            response.ErrorType = ResponseErrorType.Exception;
+            response.Exception = ex;
+        }
 
         // some HTTP error - try to parse body as JSON but allow non-JSON as well
         if (httpResponse.IsSuccessStatusCode != true &&

--- a/src/Client/StringComparisonAuthorityValidationStrategy.cs
+++ b/src/Client/StringComparisonAuthorityValidationStrategy.cs
@@ -54,6 +54,7 @@ public sealed class StringComparisonAuthorityValidationStrategy : IAuthorityVali
                 return AuthorityValidationResult.SuccessResult;
         }
 
-        return AuthorityValidationResult.CreateError($"Endpoint belongs to different authority: {endpoint}");
+        var expectedBaseAddresses = string.Join(",", allowedAuthorities);
+        return AuthorityValidationResult.CreateError($"Invalid base address for endpoint {endpoint}. Valid base addresses: {expectedBaseAddresses}.");
     }
 }

--- a/test/UnitTests/DiscoveryPolicyTests_AuthorityStringComparison.cs
+++ b/test/UnitTests/DiscoveryPolicyTests_AuthorityStringComparison.cs
@@ -258,7 +258,9 @@ namespace IdentityModel.UnitTests
             disco.IsError.Should().BeTrue();
             disco.Json?.ValueKind.Should().Be(JsonValueKind.Undefined);
             disco.ErrorType.Should().Be(ResponseErrorType.PolicyViolation);
-            disco.Error.Should().StartWith("Endpoint belongs to different authority");
+            disco.Error.Should().StartWith("Invalid base address for endpoint");
+            disco.Error.Should().Contain(endpointBase);
+            disco.Error.Should().Contain(authority);
         }
 
         [Theory]

--- a/test/UnitTests/DiscoveryPolicyTests_AuthorityUriComparison.cs
+++ b/test/UnitTests/DiscoveryPolicyTests_AuthorityUriComparison.cs
@@ -277,7 +277,9 @@ namespace IdentityModel.UnitTests
             disco.IsError.Should().BeTrue();
             disco.Json?.ValueKind.Should().Be(JsonValueKind.Undefined);
             disco.ErrorType.Should().Be(ResponseErrorType.PolicyViolation);
-            disco.Error.Should().StartWith("Endpoint belongs to different authority");
+            disco.Error.Should().StartWith("Invalid base address for endpoint");
+            disco.Error.Should().Contain(endpointBase);
+            disco.Error.Should().Contain(authority);
         }
 
         [Theory]


### PR DESCRIPTION
- Make ProtocolResponse.HttpResponse nullable (these null values already happen in error cases, so this just makes the type reflect what can actually happen) and check for null HttpResponses as necessary (fixes #532)
- Improved the error message in the case where discovery succeeds, but jwks fails 
- Don't suppress errors when reading protocol response content (fixes #507)
- Improve authority validation error message (fixes #553)