### PR TITLE
Get the URL authority when retrieving it from the HttpClient BaseAddress

### DIFF
--- a/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
+++ b/src/Client/Extensions/HttpClientDiscoveryExtensions.cs
@@ -42,7 +42,7 @@ public static class HttpClientDiscoveryExtensions
         }
         else if (client is HttpClient httpClient)
         {
-            address = httpClient.BaseAddress!.AbsoluteUri;
+            address = httpClient.BaseAddress!.GetLeftPart(UriPartial.Authority);
         }
         else
         {

--- a/test/UnitTests/HttpClientExtensions/DiscoveryExtensionsTests.cs
+++ b/test/UnitTests/HttpClientExtensions/DiscoveryExtensionsTests.cs
@@ -74,12 +74,15 @@ namespace IdentityModel.UnitTests
         }
 
 
-        [Fact]
-        public async Task Base_address_should_work()
+        [Theory]
+        [InlineData("https://demo.identityserver.io")]
+        [InlineData("https://demo.identityserver.io/api/v1/")]
+        [InlineData("https://demo.identityserver.io/.well-known/openid-configuration")]
+        public async Task Base_address_should_work(string baseAddress)
         {
             var client = new HttpClient(_successHandler)
             {
-                BaseAddress = new Uri(_endpoint)
+                BaseAddress = new Uri(baseAddress)
             };
 
             var disco = await client.GetDiscoveryDocumentAsync();


### PR DESCRIPTION
When no explicit discovery address is specified, the authority is computed from the underlying HttpClient BaseAddress property.

Before this commit: the computed authority is the full URL.

After this commit: the computed authority is the authority part of the URL.

A HttpClient BaseAddress would typically include some base path to access an API. This base path is not part of the authority.