### PR TITLE
Add Proof-of-possession of a key authentication method

### DIFF
--- a/src/OidcConstants.cs
+++ b/src/OidcConstants.cs
@@ -395,6 +395,7 @@ public static class OidcConstants
         public const string MultiFactorAuthentication = "mfa";
         public const string OneTimePassword = "otp";
         public const string PersonalIdentificationOrPattern = "pin";
+        public const string ProofOfPossessionKey = "pop";
         public const string Password = "pwd";
         public const string RiskBasedAuthentication = "rba";
         public const string RetinaScanBiometric = "retina";


### PR DESCRIPTION
Add Proof-of-possession of a key authentication method to the OidcConstants

https://www.iana.org/assignments/authentication-method-reference-values/authentication-method-reference-values.xhtml